### PR TITLE
[Beyoncé]: Add better import syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ You can specify external types you need to import like so:
 ```YAML
 Author:
     ...
-    address: author/Address
+    address: Address from author/Address
 
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ginger.io/beyonce",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Type-safe DynamoDB query builder for TypeScript. Designed with single-table architecture in mind.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/main/codegen/generateModelInterface.ts
+++ b/src/main/codegen/generateModelInterface.ts
@@ -1,4 +1,4 @@
-import { Model, Table } from "./types"
+import { Model } from "./types"
 
 export function generateModelInterfaces(
   models: Model[]
@@ -43,12 +43,12 @@ function generateField(
   name: string,
   typeName: string
 ): { code: string; imports: string[] } {
-  const parts = typeName.split("/")
+  const parts = typeName.split(" from ")
   if (parts.length > 1) {
-    const existingTypeName = parts[parts.length - 1]
+    const [existingTypeName, packageName] = parts
     return {
       code: `${name}: ${existingTypeName}`,
-      imports: [`import { ${existingTypeName} } from "${typeName}"`]
+      imports: [`import { ${existingTypeName} } from "${packageName}"`]
     }
   } else {
     return { code: `${name}: ${typeName}`, imports: [] }

--- a/src/test/codegen/generateModels.test.ts
+++ b/src/test/codegen/generateModels.test.ts
@@ -254,3 +254,26 @@ export const LibraryTable = {
 }
 `)
 })
+
+it("should import external TypeScript types from a package", () => {
+  const result = generateModels(`
+Tables:
+  Library:
+    Partitions:
+      Author: ["author", "_.authorId"]
+
+    Models:
+      Author:
+        partition: Author
+        sort: ["author", "_.authorId"]
+        id: string
+        name: BestNameEvah from @cool.io/some/sweet/package
+`)
+
+  const lines = result.split("\n").map(_ => _.trim())
+  expect(lines).toContainEqual(
+    `import { BestNameEvah } from \"@cool.io/some/sweet/package\"`
+  )
+
+  expect(lines).toContainEqual(`name: BestNameEvah`)
+})


### PR DESCRIPTION
This PR improves Beyoncé's import syntax used to reference external (imported) types from the YAML file. 

Previously, it `address: main/Address` would expand into `import { Address } from main/Address`. This wouldn't work if the file name was different than the type name. 

So now you can do `address: Address from @maps/address`, which works with almost everything. 