### PR TITLE
[Beyoncé]: Allow GSIs to use pk and sk as fields

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ const { compilerOptions } = require("./tsconfig")
 
 module.exports = {
   roots: ["<rootDir>/src"],
+  testTimeout: 10000,
   transform: {
     "^.+\\.tsx?$": "ts-jest"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ginger.io/beyonce",
-  "version": "0.0.8",
+  "version": "0.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -253,9 +253,9 @@
       }
     },
     "@ginger.io/jay-z": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@ginger.io/jay-z/-/jay-z-0.0.3.tgz",
-      "integrity": "sha512-0udrJrBRC+gp5nn0TscvGMDSD5GWPaejuiWy23Fb+pzIvtwpTNJcD0FwOvm5FURvotCypXtRrwgYsC379jxMYg==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@ginger.io/jay-z/-/jay-z-0.0.5.tgz",
+      "integrity": "sha512-hln9JrCtPtSZsoKc5xq+ZkVKHE9VP1z6u8NI/mu9eSxnM7HJRUnA0OiCOjh/Q5YAzJqM6PKBWX1C6Tz32DZ0LA==",
       "requires": {
         "aws-sdk": "^2.640.0",
         "fast-json-stable-stringify": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ginger.io/beyonce",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Type-safe DynamoDB query builder for TypeScript. Designed with single-table architecture in mind.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/main/codegen/generateGSIs.ts
+++ b/src/main/codegen/generateGSIs.ts
@@ -1,4 +1,4 @@
-import { Table } from "./types"
+import { Table, Fields } from "./types"
 import { intersection } from "./util"
 
 export function generateGSIs(table: Table): string {
@@ -10,11 +10,17 @@ export function generateGSIs(table: Table): string {
     model: []
   }
 
-  table.models.forEach(model => {
-    fieldToModels["model"].push(model.name)
+  const fieldsAllModelsHave: Fields = {
+    [table.partitionKeyName]: "string",
+    [table.sortKeyName]: "string",
+    model: "string"
+  }
 
-    for (const name in model.fields) {
-      fieldToType[name] = model.fields[name]
+  table.models.forEach(model => {
+    const fields = { ...fieldsAllModelsHave, ...model.fields }
+
+    for (const name in fields) {
+      fieldToType[name] = fields[name]
       fieldToModels[name] = fieldToModels[name] || []
       fieldToModels[name].push(model.name)
     }

--- a/src/main/codegen/generateModels.ts
+++ b/src/main/codegen/generateModels.ts
@@ -49,6 +49,8 @@ function toTables(config: ModelDefinitions): Table[] {
     ([name, { Partitions, Models, GSIs }]) => {
       const table: Table = {
         name,
+        partitionKeyName: "pk",
+        sortKeyName: "sk",
         partitions: Partitions,
         gsis: [],
         models: []

--- a/src/main/codegen/types.ts
+++ b/src/main/codegen/types.ts
@@ -19,6 +19,8 @@ export type ModelDefinitions = {
 
 export type Table = {
   name: string
+  partitionKeyName: string
+  sortKeyName: string
   partitions: { [partition: string]: string[] }
   gsis: GSI[]
   models: Model[]


### PR DESCRIPTION
This PR extends GSI support in Beyoncé to allow referencing the (base) table's partition and sort keys.  This is useful as it's a common use-case to want to "swap" these keys in a GSI - i.e. GSI pk = Table sk, GSI sk = Table pk. 