### PR TITLE
Make "Model" type a union of all specified models

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ginger.io/beyonce",
-  "version": "0.0.13",
+  "version": "0.0.15",
   "description": "Type-safe DynamoDB query builder for TypeScript. Designed with single-table architecture in mind.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/main/codegen/generateModelHelpers.ts
+++ b/src/main/codegen/generateModelHelpers.ts
@@ -1,8 +1,8 @@
 import { Model } from "./types"
 
 export function generateModelHelpers(models: Model[]): string {
-  const helpers = models.map(m => {
-    const modelHelperName = m.name.replace(/^\w/, _ => _.toLowerCase())
+  const helpers = models.map((m) => {
+    const modelHelperName = m.name.replace(/^\w/, (_) => _.toLowerCase())
 
     return `export function ${modelHelperName}(fields: Omit<${m.name}, "model">): ${m.name} {
         return {

--- a/src/main/codegen/generateModels.ts
+++ b/src/main/codegen/generateModels.ts
@@ -6,6 +6,7 @@ import { generateModelTypeEnum } from "./generateModelTypeEnum"
 import { generateTables } from "./generateTables"
 import { ModelDefinitions, Table } from "./types"
 import { generateModelHelpers } from "./generateModelHelpers"
+import { generateTaggedUnion } from "./generateTaggedUnion"
 
 export function generateModels(yamlData: string): string {
   const config = parseYaml<ModelDefinitions>(yamlData)
@@ -18,9 +19,10 @@ export function generateModels(yamlData: string): string {
   const modelInterfaces = generateModelInterfaces(models)
   const modelTypeEnum = generateModelTypeEnum(models)
   const tables = generateTables(tableDefs)
+  const taggedUnion = generateTaggedUnion(models)
 
   const imports = new Set([`import { key, Model } from "@ginger.io/beyonce"`])
-  modelInterfaces.imports.forEach(_ => imports.add(_))
+  modelInterfaces.imports.forEach((_) => imports.add(_))
 
   const modelHelpers = generateModelHelpers(models)
 
@@ -33,12 +35,14 @@ export function generateModels(yamlData: string): string {
 
       ${modelHelpers}
 
+      ${taggedUnion}
+
       ${tables}
     `
 
   return prettier.format(code, {
     parser: "typescript",
-    semi: false
+    semi: false,
   })
 }
 
@@ -53,7 +57,7 @@ function toTables(config: ModelDefinitions): Table[] {
         sortKeyName: "sk",
         partitions: Partitions,
         gsis: [],
-        models: []
+        models: [],
       }
 
       if (GSIs !== undefined) {
@@ -68,7 +72,7 @@ function toTables(config: ModelDefinitions): Table[] {
             name,
             partition,
             sort,
-            fields
+            fields,
           })
         }
       )

--- a/src/main/codegen/generateTaggedUnion.ts
+++ b/src/main/codegen/generateTaggedUnion.ts
@@ -1,0 +1,6 @@
+import { Model } from "./types"
+
+export function generateTaggedUnion(models: Model[]): string {
+  const union = models.map((_) => _.name).join(" | ")
+  return `export type Model = ${union}`
+}

--- a/src/main/dynamo/Beyonce.ts
+++ b/src/main/dynamo/Beyonce.ts
@@ -1,7 +1,6 @@
 import { DynamoDB } from "aws-sdk"
 import { JayZConfig } from "./JayZConfig"
 import { Key } from "./Key"
-import { Model } from "./Model"
 import { QueryBuilder } from "./QueryBuilder"
 import {
   decryptOrPassThroughItem,
@@ -36,9 +35,7 @@ export class Beyonce {
   }
 
   /** Retrieve a single Item out of Dynamo */
-  async get<T extends Model, U extends Model>(
-    key: PartitionAndSortKey<T, U>
-  ): Promise<U | undefined> {
+  async get<T, U>(key: PartitionAndSortKey<T, U>): Promise<U | undefined> {
     const { Item: item } = await this.client
       .get({
         TableName: this.tableName,
@@ -55,7 +52,7 @@ export class Beyonce {
   }
 
   /** BatchGet items */
-  async batchGet<T extends Model>(params: {
+  async batchGet<T>(params: {
     keys: PartitionAndSortKey<any, T>[]
   }): Promise<T[]> {
     const {
@@ -91,7 +88,7 @@ export class Beyonce {
     }
   }
 
-  query<T extends Model>(pk: Key<T>): QueryBuilder<T> {
+  query<T>(pk: Key<T>): QueryBuilder<T> {
     const { tableName, jayz } = this
     return new QueryBuilder<T>({
       db: this.client,
@@ -101,7 +98,7 @@ export class Beyonce {
     })
   }
 
-  queryGSI<T extends Model>(gsiName: string, gsiPk: Key<T>): QueryBuilder<T> {
+  queryGSI<T>(gsiName: string, gsiPk: Key<T>): QueryBuilder<T> {
     const { tableName, jayz } = this
     return new QueryBuilder<T>({
       db: this.client,
@@ -113,7 +110,7 @@ export class Beyonce {
   }
 
   /** Write an item into Dynamo */
-  async put<T extends Model>(itemAndKey: ItemAndKey<T>): Promise<void> {
+  async put<T>(itemAndKey: ItemAndKey<T>): Promise<void> {
     const item = await this.maybeEncryptItems(itemAndKey)
 
     await this.client
@@ -126,9 +123,7 @@ export class Beyonce {
 
   /** Write multiple items into Dynamo using a transaction.
    */
-  async batchPutWithTransaction<T extends Model>(
-    items: ItemAndKey<T>[]
-  ): Promise<void> {
+  async batchPutWithTransaction<T>(items: ItemAndKey<T>[]): Promise<void> {
     const asyncEncryptedItems = items.map(async (itemAndKey) => {
       const maybeEncryptedItem = await this.maybeEncryptItems(itemAndKey)
       return { Put: { TableName: this.tableName, Item: maybeEncryptedItem } }
@@ -143,7 +138,7 @@ export class Beyonce {
       .promise()
   }
 
-  private async maybeEncryptItems<T extends Model>(
+  private async maybeEncryptItems<T>(
     itemAndKey: ItemAndKey<T>
   ): Promise<MaybeEncryptedItems<T>> {
     const { item, key } = itemAndKey

--- a/src/main/dynamo/Key.ts
+++ b/src/main/dynamo/Key.ts
@@ -1,13 +1,11 @@
-import { Model } from "./Model"
-
 /** A DynamoDB partition or sort key. T is the type of model that lives under this key in Dynamo
  *  (it might be a union type or a single type). And we use a class here to "hold onto" that type
  */
-export class Key<T extends Model> {
+export class Key<T> {
   constructor(public readonly name: string, public readonly value: string) {}
 }
 
-export function key<T, U extends Model>(
+export function key<T, U>(
   name: string,
   createKey: (input: T) => string[]
 ): (input: T) => Key<U> {

--- a/src/main/dynamo/Model.ts
+++ b/src/main/dynamo/Model.ts
@@ -1,3 +1,0 @@
-export interface Model {
-  model: string
-}

--- a/src/main/dynamo/util.ts
+++ b/src/main/dynamo/util.ts
@@ -1,19 +1,18 @@
 import { EncryptedJayZItem } from "@ginger.io/jay-z"
 import { JayZConfig } from "./JayZConfig"
 import { Key } from "./Key"
-import { Model } from "./Model"
 
-export type ItemAndKey<T extends Model> = {
+export type ItemAndKey<T> = {
   key: PartitionAndSortKey<any, T>
   item: T
 }
 
-export type PartitionAndSortKey<T extends Model, U extends Model> = {
+export type PartitionAndSortKey<T, U> = {
   partition: Key<T>
   sort: Key<U>
 }
 
-export type MaybeEncryptedItems<T extends Model> =
+export type MaybeEncryptedItems<T> =
   | EncryptedJayZItem<
       T & {
         [key: string]: string
@@ -28,7 +27,7 @@ export function toJSON<T>(item: { [key: string]: any }): T {
   return item as T
 }
 
-export async function encryptOrPassThroughItems<T extends Model>(
+export async function encryptOrPassThroughItems<T>(
   jayz: JayZConfig | undefined,
   item: T & { [key: string]: string }
 ): Promise<MaybeEncryptedItems<T>> {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,3 +1,2 @@
 export { Beyonce } from "./dynamo/Beyonce"
 export { key } from "./dynamo/Key"
-export { Model } from "./dynamo/Model"

--- a/src/test/codegen/generateModels.test.ts
+++ b/src/test/codegen/generateModels.test.ts
@@ -44,6 +44,8 @@ const authorAndBookSk = `sk: {
     ])
   }`
 
+const authorAndBookUnion = `export type Model = Author | Book`
+
 it("should generate a simple model", () => {
   const result = generateModels(`
 Tables:
@@ -68,6 +70,8 @@ export enum ModelType {
 ${authorInterface}
 
 ${authorHelper}
+
+export type Model = Author
 
 export const LibraryTable = {
   name: "Library",
@@ -122,6 +126,8 @@ ${authorHelper}
 
 ${bookHelper}
 
+${authorAndBookUnion}
+
 export const LibraryTable = {
   name: "Library",
   encryptionBlacklist: new Set(["pk", "sk", "model", "__jayz__metadata"]),
@@ -172,6 +178,8 @@ ${bookInterface}
 ${authorHelper}
 
 ${bookHelper}
+
+${authorAndBookUnion}
 
 export const LibraryTable = {
   name: "Library",
@@ -230,6 +238,8 @@ ${bookInterface}
 ${authorHelper}
 
 ${bookHelper}
+
+${authorAndBookUnion}
 
 export const LibraryTable = {
   name: "Library",
@@ -314,7 +324,7 @@ Tables:
         name: BestNameEvah from @cool.io/some/sweet/package
 `)
 
-  const lines = result.split("\n").map(_ => _.trim())
+  const lines = result.split("\n").map((_) => _.trim())
   expect(lines).toContainEqual(
     `import { BestNameEvah } from \"@cool.io/some/sweet/package\"`
   )


### PR DESCRIPTION
This PR updates Beyonce's `Model` type to be a tagged union of all the specified models. So

`interface Model { name: string }` becomes `type Model = Author | Book` . This makes it easy to "pattern match" in downstream code. 