### PR TITLE
[Beyonce]: Cleanup JayZ Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,10 +231,7 @@ const jayZ = new JayZ({ keyProvider })
 const beyonce = new Beyonce(
   LibraryTable,
   dynamo,
-  {
-    jayz,
-    encryptionBlacklist: LibraryTable.getEncryptionBlacklist()
-  }
+  { jayz }
 )
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ginger.io/beyonce",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "Type-safe DynamoDB query builder for TypeScript. Designed with single-table architecture in mind.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/main/codegen/generateGSIs.ts
+++ b/src/main/codegen/generateGSIs.ts
@@ -26,13 +26,15 @@ function generateGSIsForTable(table: Table): string {
     })
   })
 
-  const gsis = table.gsis.map(({ name, partitionKey }) => {
+  const gsis = table.gsis.map(({ name, partitionKey, sortKey }) => {
     const pk = partitionKey.replace("$", "")
+    const sk = sortKey.replace("$", "")
     const models = fieldToModels[pk].map((_) => `${_}Model`).join(", ")
 
     return `const ${name}GSI = ${table.name}Table.gsi("${name}")
       .models([${models}])
       .partitionKey("${pk}")
+      .sortKey("${sk}")
     `
   })
 

--- a/src/main/dynamo/Beyonce.ts
+++ b/src/main/dynamo/Beyonce.ts
@@ -1,8 +1,8 @@
+import { JayZ } from "@ginger.io/jay-z"
 import { DynamoDB } from "aws-sdk"
 import { PartitionAndSortKey, PartitionKey } from "./keys"
-import { Table } from "./Table"
-import { JayZConfig } from "./JayZConfig"
 import { QueryBuilder } from "./QueryBuilder"
+import { Table } from "./Table"
 import {
   decryptOrPassThroughItem,
   encryptOrPassThroughItems,
@@ -11,7 +11,7 @@ import {
 } from "./util"
 
 export type Options = {
-  jayz?: JayZConfig
+  jayz?: JayZ
 }
 
 export type ExtractKeyType<T> = T extends PartitionAndSortKey<infer U>
@@ -23,7 +23,7 @@ export type ExtractKeyType<T> = T extends PartitionAndSortKey<infer U>
  */
 export class Beyonce {
   private client: DynamoDB.DocumentClient
-  private jayz?: JayZConfig
+  private jayz?: JayZ
 
   constructor(private table: Table, dynamo: DynamoDB, options: Options = {}) {
     this.client = new DynamoDB.DocumentClient({ service: dynamo })
@@ -144,7 +144,12 @@ export class Beyonce {
   private async maybeEncryptItems<T extends Record<string, any>>(
     item: T
   ): Promise<MaybeEncryptedItems<T>> {
-    const maybeEncryptedItems = await encryptOrPassThroughItems(this.jayz, item)
-    return maybeEncryptedItems
+    const { jayz, table } = this
+
+    return await encryptOrPassThroughItems(
+      jayz,
+      item,
+      table.getEncryptionBlacklist()
+    )
   }
 }

--- a/src/main/dynamo/JayZConfig.ts
+++ b/src/main/dynamo/JayZConfig.ts
@@ -1,6 +1,0 @@
-import { JayZ } from "@ginger.io/jay-z"
-
-export type JayZConfig = {
-  client: JayZ
-  encryptionBlacklist: Set<string>
-}

--- a/src/main/dynamo/util.ts
+++ b/src/main/dynamo/util.ts
@@ -1,5 +1,4 @@
-import { EncryptedJayZItem } from "@ginger.io/jay-z"
-import { JayZConfig } from "./JayZConfig"
+import { EncryptedJayZItem, JayZ } from "@ginger.io/jay-z"
 
 export type MaybeEncryptedItems<T> =
   | EncryptedJayZItem<
@@ -15,25 +14,26 @@ export function toJSON<T>(item: { [key: string]: any }): T {
 }
 
 export async function encryptOrPassThroughItems<T extends Record<string, any>>(
-  jayz: JayZConfig | undefined,
-  item: T
+  jayz: JayZ | undefined,
+  item: T,
+  encryptionBlacklist: Set<string>
 ): Promise<MaybeEncryptedItems<T>> {
   if (jayz !== undefined) {
     const fieldsToEncrypt = Object.keys(item).filter(
-      (_) => !jayz.encryptionBlacklist.has(_)
+      (_) => !encryptionBlacklist.has(_)
     )
-    return jayz.client.encryptItem(item, fieldsToEncrypt)
+    return jayz.encryptItem(item, fieldsToEncrypt)
   } else {
     return item
   }
 }
 
 export async function decryptOrPassThroughItem(
-  jayz: JayZConfig | undefined,
+  jayz: JayZ | undefined,
   item: Record<string, any>
 ): Promise<{ [key: string]: any }> {
   if (jayz !== undefined) {
-    return jayz.client.decryptItem(item as EncryptedJayZItem<any, any>)
+    return jayz.decryptItem(item as EncryptedJayZItem<any, any>)
   } else {
     return item
   }

--- a/src/test/codegen/generateCode.test.ts
+++ b/src/test/codegen/generateCode.test.ts
@@ -128,6 +128,7 @@ Tables:
   expect(result).toContain(`const modelByIdGSI = LibraryTable.gsi("modelById")
   .models([AuthorModel, BookModel])
   .partitionKey("model")
+  .sortKey("id")
 `)
 })
 
@@ -189,7 +190,8 @@ Tables:
   expect(result)
     .toContain(`const byNameAndIdGSI = LibraryTable.gsi("byNameAndId")
   .models([AuthorModel, BookModel])
-  .partitionKey("sk")`)
+  .partitionKey("sk")
+  .sortKey("pk")`)
 })
 
 it("should import external TypeScript types from a package", () => {

--- a/src/test/dynamo/models.ts
+++ b/src/test/dynamo/models.ts
@@ -40,11 +40,13 @@ export const byModelAndIdGSI = table
   .gsi("byModelAndId")
   .models([MusicianModel, SongModel])
   .partitionKey("model")
+  .sortKey("id")
 
 export const byNameAndIdGSI = table
   .gsi("byNameAndId")
   .models([MusicianModel])
   .partitionKey("name")
+  .sortKey("id")
 
 export function aMusicianWithTwoSongs(): [Musician, Song, Song] {
   const musician = MusicianModel.create({


### PR DESCRIPTION
Previously when enabling JayZ encryption w/ Beyonce you had to explicitly pass a set of fields to avoid encrypting. 

But now the (generated) `Table` class is aware of which fields to avoid encrypting (because it knows the partition/sort keys for the table + gsis on the table). So there's no need to do that. 

This PR cleans this up. 