### PR TITLE
[Beyonce]: Support querying for single type of model 

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ const results = await beyonce
   .exec() // returns { Book: Book[] }
 ```
 
-To reduce the amount of data retrieved by DynamoDB, Beyoncé automatically applies a `KeyConditionExpression` that uses the `sortKey` prefix provided in your model definitions. For example, if the YAML definition for the `Book` model contains `sortKey:[Book, $id]` -- then the generated `KeyConditionExpression` will contain a clause like `#partitionKey = :partitionKey AND begins_with(#sortKey, :Book)`.
+To reduce the amount of data retrieved by DynamoDB, Beyoncé automatically applies a `KeyConditionExpression` that uses the `sortKey` prefix provided in your model definitions. For example, if the YAML definition for the `Book` model contains `sortKey:[Book, $id]` -- then the generated `KeyConditionExpression` will contain a clause like `#partitionKey = :partitionKey AND begins_with(#sortKey, Book)`.
 
 #### Query for all models in a partition
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ginger.io/beyonce",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "Type-safe DynamoDB query builder for TypeScript. Designed with single-table architecture in mind.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/main/dynamo/Beyonce.ts
+++ b/src/main/dynamo/Beyonce.ts
@@ -1,7 +1,11 @@
 import { JayZ } from "@ginger.io/jay-z"
 import { DynamoDB } from "aws-sdk"
 import { groupModelsByType } from "./groupModelsByType"
-import { PartitionAndSortKey, PartitionKey } from "./keys"
+import {
+  PartitionAndSortKey,
+  PartitionKey,
+  PartitionKeyAndSortKeyPrefix,
+} from "./keys"
 import { QueryBuilder } from "./QueryBuilder"
 import { Table } from "./Table"
 import { ExtractKeyType, GroupedModels, TaggedModel } from "./types"
@@ -88,26 +92,28 @@ export class Beyonce {
     }
   }
 
-  query<T extends TaggedModel>(pk: PartitionKey<T>): QueryBuilder<T> {
+  query<T extends TaggedModel>(
+    key: PartitionKey<T> | PartitionKeyAndSortKeyPrefix<T>
+  ): QueryBuilder<T> {
     const { table, jayz } = this
     return new QueryBuilder<T>({
       db: this.client,
       table,
-      pk,
+      key,
       jayz: jayz,
     })
   }
 
   queryGSI<T extends TaggedModel>(
     gsiName: string,
-    gsiPk: PartitionKey<T>
+    gsiKey: PartitionKey<T>
   ): QueryBuilder<T> {
     const { table, jayz } = this
     return new QueryBuilder<T>({
       db: this.client,
       table,
       gsiName,
-      gsiPk,
+      gsiKey,
       jayz,
     })
   }

--- a/src/main/dynamo/Model.ts
+++ b/src/main/dynamo/Model.ts
@@ -1,4 +1,8 @@
-import { PartitionAndSortKey, PartitionKey } from "./keys"
+import {
+  PartitionAndSortKey,
+  PartitionKey,
+  PartitionKeyAndSortKeyPrefix,
+} from "./keys"
 import { Table } from "./Table"
 import { TaggedModel } from "./types"
 
@@ -34,11 +38,13 @@ export class Model<
     )
   }
 
-  partitionKey(params: { [X in U]: string }): PartitionKey<T> {
+  partitionKey(params: { [X in U]: string }): PartitionKeyAndSortKeyPrefix<T> {
     const { partitionKeyPrefix, partitionKeyField } = this
-    return new PartitionKey(
+    return new PartitionKeyAndSortKeyPrefix(
       this.table.partitionKeyName,
-      this.buildKey(partitionKeyPrefix, params[partitionKeyField])
+      this.buildKey(partitionKeyPrefix, params[partitionKeyField]),
+      this.table.sortKeyName,
+      this.sortKeyPrefix
     )
   }
 

--- a/src/main/dynamo/keys.ts
+++ b/src/main/dynamo/keys.ts
@@ -5,6 +5,15 @@ export class PartitionKey<T> {
   ) {}
 }
 
+export class PartitionKeyAndSortKeyPrefix<T> {
+  constructor(
+    readonly partitionKeyName: string,
+    readonly partitionKey: string,
+    readonly sortKeyName: string,
+    readonly sortKeyPrefix: string
+  ) {}
+}
+
 export class PartitionAndSortKey<T> {
   constructor(
     readonly partitionKeyName: string,

--- a/src/test/dynamo/ExpressionBuilder.test.ts
+++ b/src/test/dynamo/ExpressionBuilder.test.ts
@@ -2,7 +2,7 @@ import { ExpressionBuilder } from "../../main/dynamo/ExpressionBuilder"
 import { Musician } from "./models"
 import { Operator } from "../../main/dynamo/ExpressionBuilder"
 
-describe("ExpressionBuilder where + or + and clauses", () => {
+describe("ExpressionBuilder basic clauses", () => {
   it("doing nothing should yield blank expression", () => {
     const result = exp().build()
     expect(result).toEqual({


### PR DESCRIPTION
This PR adds functionality to `.query` and retrieve a single type of model (e.g. give me all books for author 123).  

To reduce the amount of data processed by DynamoDB when making this type of query, we also now automatically apply a `KeyConditionExpression` that enforces that the table's sortKey begins with the specified model's prefix (e.g. `begins_with(..., Book)`). 