### PR TITLE
[Beyoncé]: Add pagination support

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,23 @@ const authorWithFilteredBooks = await beyonce
   .exec()
 ```
 
+#### Paginating Queries
+
+When you call `.exec()` Beyoncé will automatically page through all the results and return them to you. If you would like to step through pages manually (e.g to throttle reads) -- use the `.iterator()` method instead:
+
+```TypeScript
+const iterator = beyonce
+  .query(AuthorPartition.key({ id: "1" }))
+  .iterator({ pageSize: 1 })
+
+const firstPage = await iterator.next()
+console.log("First Page: ", firstPage.value.items)
+
+if (!fistPage.done) {
+  const secondPage = await iterator.next({ cursor: firstPage.value.cursor })
+}
+```
+
 ### QueryGSI
 
 ```TypeScript

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ginger.io/beyonce",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "Type-safe DynamoDB query builder for TypeScript. Designed with single-table architecture in mind.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/test/dynamo/Beyonce.test.ts
+++ b/src/test/dynamo/Beyonce.test.ts
@@ -212,12 +212,12 @@ async function testQueryWithLimit(jayZ?: JayZ) {
   const [musician, song1, song2] = aMusicianWithTwoSongs()
   await Promise.all([db.put(musician), db.put(song1), db.put(song2)])
 
-  const result = await db
+  const { value } = await db
     .query(MusicianPartition.key({ id: musician.id }))
-    .maxRecordsToProcess(1)
-    .exec()
+    .pages({ size: 1 })
+    .next()
 
-  expect(result).toEqual({ musician: [musician] })
+  expect(value).toEqual({ musician: [musician] })
 }
 
 async function testQueryWithReverseAndLimit(jayZ?: JayZ) {
@@ -225,13 +225,13 @@ async function testQueryWithReverseAndLimit(jayZ?: JayZ) {
   const [_, song1, song2] = aMusicianWithTwoSongs()
   await Promise.all([db.put(song1), db.put(song2)])
 
-  const result = await db
+  const { value } = await db
     .query(MusicianPartition.key({ id: song1.musicianId }))
-    .maxRecordsToProcess(1)
     .reverse()
-    .exec()
+    .pages({ size: 1 })
+    .next()
 
-  expect(result).toEqual({ song: [song2] })
+  expect(value).toEqual({ song: [song2] })
 }
 
 async function testBatchGet(jayZ?: JayZ) {


### PR DESCRIPTION
This PR adds the ability to manually step through pages of a query result, which is useful if you want to throttle reads and/or send paginated results + a cursor down to a client. 