### PR TITLE
[Beyonce]: Return empty lists when items not found in Query / BatchGet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ginger.io/beyonce",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "description": "Type-safe DynamoDB query builder for TypeScript. Designed with single-table architecture in mind.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/main/dynamo/Beyonce.ts
+++ b/src/main/dynamo/Beyonce.ts
@@ -78,6 +78,7 @@ export class Beyonce {
       console.error("Some keys didn't process", unprocessedKeys)
     }
 
+    const modelTags = params.keys.map((_) => _.modelTag)
     if (responses !== undefined) {
       const items = responses[this.table.tableName]
       const jsonItemPromises = items.map(async (_) => {
@@ -86,9 +87,9 @@ export class Beyonce {
       })
 
       const jsonItems = await Promise.all(jsonItemPromises)
-      return groupModelsByType(jsonItems)
+      return groupModelsByType(jsonItems, modelTags)
     } else {
-      return groupModelsByType<ExtractKeyType<T>>([])
+      return groupModelsByType<ExtractKeyType<T>>([], modelTags)
     }
   }
 

--- a/src/main/dynamo/Beyonce.ts
+++ b/src/main/dynamo/Beyonce.ts
@@ -79,6 +79,7 @@ export class Beyonce {
     }
 
     const modelTags = params.keys.map((_) => _.modelTag)
+
     if (responses !== undefined) {
       const items = responses[this.table.tableName]
       const jsonItemPromises = items.map(async (_) => {

--- a/src/main/dynamo/GSI.ts
+++ b/src/main/dynamo/GSI.ts
@@ -6,6 +6,8 @@ import { ExtractFields } from "./types"
 type StringKey<T> = keyof ExtractFields<T> & string
 
 export class GSI<T extends Model<any, any, any>> {
+  private modelTags: string[]
+
   constructor(
     private table: Table,
     readonly name: string,
@@ -15,10 +17,11 @@ export class GSI<T extends Model<any, any, any>> {
   ) {
     this.table.addToEncryptionBlacklist(this.partitionKeyName)
     this.table.addToEncryptionBlacklist(this.sortKeyName)
+    this.modelTags = models.map((_) => _.modelTag)
   }
 
   key(partitionKey: string): PartitionKey<ExtractFields<T>> {
-    return new PartitionKey(this.partitionKeyName, partitionKey)
+    return new PartitionKey(this.partitionKeyName, partitionKey, this.modelTags)
   }
 }
 

--- a/src/main/dynamo/Model.ts
+++ b/src/main/dynamo/Model.ts
@@ -1,8 +1,4 @@
-import {
-  PartitionAndSortKey,
-  PartitionKey,
-  PartitionKeyAndSortKeyPrefix,
-} from "./keys"
+import { PartitionAndSortKey, PartitionKeyAndSortKeyPrefix } from "./keys"
 import { Table } from "./Table"
 import { TaggedModel } from "./types"
 
@@ -17,7 +13,7 @@ export class Model<
     private partitionKeyField: U,
     private sortKeyPrefix: string,
     private sortKeyField: V,
-    private modelTag: string
+    readonly modelTag: string
   ) {}
 
   key(
@@ -34,7 +30,8 @@ export class Model<
       this.buildKey(partitionKeyPrefix, params[partitionKeyField]),
 
       this.table.sortKeyName,
-      this.buildKey(sortKeyPrefix, params[sortKeyField])
+      this.buildKey(sortKeyPrefix, params[sortKeyField]),
+      this.modelTag
     )
   }
 
@@ -44,7 +41,8 @@ export class Model<
       this.table.partitionKeyName,
       this.buildKey(partitionKeyPrefix, params[partitionKeyField]),
       this.table.sortKeyName,
-      this.sortKeyPrefix
+      this.sortKeyPrefix,
+      this.modelTag
     )
   }
 

--- a/src/main/dynamo/Partition.ts
+++ b/src/main/dynamo/Partition.ts
@@ -7,6 +7,7 @@ export class Partition<
   U extends Model<any, any, any>
 > {
   private modelTags: string[]
+
   constructor(private models: [T, ...U[]]) {
     this.modelTags = models.map((_) => _.modelTag)
   }

--- a/src/main/dynamo/Partition.ts
+++ b/src/main/dynamo/Partition.ts
@@ -6,7 +6,10 @@ export class Partition<
   T extends Model<any, any, any>,
   U extends Model<any, any, any>
 > {
-  constructor(private models: [T, ...U[]]) {}
+  private modelTags: string[]
+  constructor(private models: [T, ...U[]]) {
+    this.modelTags = models.map((_) => _.modelTag)
+  }
 
   /** Since we assume that all this.models[] live under the same partition
    *  we can generate a valid partition key by calling models[0].partitionKey
@@ -20,7 +23,8 @@ export class Partition<
     )
     return new PartitionKey<ExtractFields<T | U>>(
       partitionKeyName,
-      partitionKey
+      partitionKey,
+      this.modelTags
     )
   }
 }

--- a/src/main/dynamo/groupModelsByType.ts
+++ b/src/main/dynamo/groupModelsByType.ts
@@ -1,13 +1,17 @@
 import { GroupedModels, TaggedModel } from "./types"
 
 export function groupModelsByType<T extends TaggedModel>(
-  models: T[]
+  models: T[],
+  modelTags: T["model"][]
 ): GroupedModels<T> {
   const groups = {} as GroupedModels<T>
 
+  modelTags.forEach((tag) => {
+    groups[tag] = [] as any
+  })
+
   models.forEach((m) => {
     const modelType = m.model as T["model"]
-    groups[modelType] = groups[modelType] || []
     groups[modelType].push(m)
   })
 

--- a/src/main/dynamo/keys.ts
+++ b/src/main/dynamo/keys.ts
@@ -1,25 +1,30 @@
-export class PartitionKey<T> {
+import { TaggedModel } from "./types"
+
+export class PartitionKey<T extends TaggedModel> {
   constructor(
     readonly partitionKeyName: string,
-    readonly partitionKey: string
+    readonly partitionKey: string,
+    readonly modelTags: T["model"][]
   ) {}
 }
 
-export class PartitionKeyAndSortKeyPrefix<T> {
+export class PartitionKeyAndSortKeyPrefix<T extends TaggedModel> {
   constructor(
     readonly partitionKeyName: string,
     readonly partitionKey: string,
     readonly sortKeyName: string,
-    readonly sortKeyPrefix: string
+    readonly sortKeyPrefix: string,
+    readonly modelTag: T["model"]
   ) {}
 }
 
-export class PartitionAndSortKey<T> {
+export class PartitionAndSortKey<T extends TaggedModel> {
   constructor(
     readonly partitionKeyName: string,
     readonly partitionKey: string,
     readonly sortKeyName: string,
-    readonly sortKey: string
+    readonly sortKey: string,
+    readonly modelTag: T["model"]
   ) {}
 
   // Required to avoid TypeScript's structural typing from collapsing

--- a/src/test/dynamo/Beyonce.test.ts
+++ b/src/test/dynamo/Beyonce.test.ts
@@ -42,6 +42,10 @@ describe("Beyonce", () => {
     await testBatchGet()
   })
 
+  it("should return empty arrays when no items found during batchGet", async () => {
+    await testEmptyBatchGet()
+  })
+
   // GSIs
   it("should query GSI by model", async () => {
     await testGSIByModel()
@@ -101,6 +105,11 @@ describe("Beyonce", () => {
   it("should batchGet items with jayZ", async () => {
     const jayZ = await createJayZ()
     await testBatchGet(jayZ)
+  })
+
+  it("should return empty arrays when no items found during batchGet with jayZ", async () => {
+    const jayZ = await createJayZ()
+    await testEmptyBatchGet(jayZ)
   })
 
   it("should query GSI by model with jayZ", async () => {
@@ -279,6 +288,23 @@ async function testBatchGet(jayZ?: JayZ) {
   expect(results).toEqual({
     musician: [musician],
     song: [song1, song2],
+  })
+}
+
+async function testEmptyBatchGet(jayZ?: JayZ) {
+  const db = await setup(jayZ)
+  const [musician, song1, song2] = aMusicianWithTwoSongs()
+  const results = await db.batchGet({
+    keys: [
+      MusicianModel.key({ id: musician.id }),
+      SongModel.key({ musicianId: musician.id, id: song1.id }),
+      SongModel.key({ musicianId: musician.id, id: song2.id }),
+    ],
+  })
+
+  expect(results).toEqual({
+    musician: [],
+    song: [],
   })
 }
 


### PR DESCRIPTION
This PR adjusts `.query` and `.batchGet` to return empty arrays for model types that could potentially be returned from the db. Previously if no models of that type were found, the model type key would come back as undefined. 

Fixes #24 