### PR TITLE
[Beyonce]: Support partial updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,20 @@ const author = await beyonce.get(AuthorModel.key({ id: "1" }))
 
 Note: the key `prefix` ("Author" from our earlier example) will be automatically appeneded.
 
+### Update
+
+Beyoncé supports performing type-safe partial updates on items even through nested attributes.
+
+```TypeScript
+const updatedAuthor = await beyonce.update(AuthorModel.key({ id: "1" }), (author) => {
+  author.name = "Jack London",
+  author.details.description = "American novelist"
+  delete author.details.someDeprecatedField
+})
+```
+
+Here `beyonce.update(...)` returns the full `Author`, with the updated fields.
+
 ### Query
 
 Beyoncé supports type-safe `query` operations that either return a single model type or all model types that live under a given partition key.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ Note: the key `prefix` ("Author" from our earlier example) will be automatically
 
 ### Update
 
-Beyoncé supports performing type-safe partial updates on items even through nested attributes.
+Beyoncé supports type-safe partial updates on items, without having to read the item from the db first.
+And it works, even through nested attributes:
 
 ```TypeScript
 const updatedAuthor = await beyonce.update(AuthorModel.key({ id: "1" }), (author) => {
@@ -144,7 +145,8 @@ const updatedAuthor = await beyonce.update(AuthorModel.key({ id: "1" }), (author
 })
 ```
 
-Here `beyonce.update(...)` returns the full `Author`, with the updated fields.
+Here `author` is an intelligent proxy object (thus we avoid having to read the full item from the DB prior to updating it).
+And `beyonce.update(...)` returns the full `Author`, with the updated fields.
 
 ### Query
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ginger.io/beyonce",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "description": "Type-safe DynamoDB query builder for TypeScript. Designed with single-table architecture in mind.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/main/dynamo/QueryBuilder.ts
+++ b/src/main/dynamo/QueryBuilder.ts
@@ -1,8 +1,8 @@
 import { JayZ } from "@ginger.io/jay-z"
 import { DynamoDB } from "aws-sdk"
-import { ExpressionBuilder } from "./ExpressionBuilder"
 import { groupModelsByType } from "./groupModelsByType"
 import { PartitionKey, PartitionKeyAndSortKeyPrefix } from "./keys"
+import { QueryExpressionBuilder } from "./expressions/QueryExpressionBuilder"
 import { Table } from "./Table"
 import { GroupedModels, TaggedModel } from "./types"
 import { decryptOrPassThroughItem, toJSON } from "./util"
@@ -47,7 +47,9 @@ type RawQueryResults<T extends TaggedModel> = {
 }
 
 /** Builds and executes parameters for a DynamoDB Query operation */
-export class QueryBuilder<T extends TaggedModel> extends ExpressionBuilder<T> {
+export class QueryBuilder<T extends TaggedModel> extends QueryExpressionBuilder<
+  T
+> {
   private scanIndexForward: boolean = true
   private modelTags: string[] = getModelTags(this.config)
 

--- a/src/main/dynamo/expressions/Attributes.ts
+++ b/src/main/dynamo/expressions/Attributes.ts
@@ -1,0 +1,13 @@
+export class Attributes {
+  private substitutions: { [key: string]: string } = {}
+
+  add(attribute: string): string {
+    const placeholder = `#${attribute}`
+    this.substitutions[placeholder] = attribute
+    return placeholder
+  }
+
+  getSubstitutions(): Readonly<{ [key: string]: string }> {
+    return this.substitutions
+  }
+}

--- a/src/main/dynamo/expressions/DynamoDBExpression.ts
+++ b/src/main/dynamo/expressions/DynamoDBExpression.ts
@@ -1,0 +1,7 @@
+import { DynamoDB } from "aws-sdk"
+
+export type DynamoDBExpression = {
+  expression: DynamoDB.DocumentClient.ConditionExpression
+  attributeNames: DynamoDB.DocumentClient.ExpressionAttributeNameMap
+  attributeValues: DynamoDB.DocumentClient.ExpressionAttributeValueMap
+}

--- a/src/main/dynamo/expressions/UpdateItemExpressionBuilder.ts
+++ b/src/main/dynamo/expressions/UpdateItemExpressionBuilder.ts
@@ -1,0 +1,84 @@
+import { PartitionAndSortKey } from "../keys"
+import { TaggedModel } from "../types"
+import { Attributes } from "./Attributes"
+import { DynamoDBExpression } from "./DynamoDBExpression"
+import { Variables } from "./Variables"
+
+export class UpdateItemExpressionBuilder {
+  private attributeNames = new Attributes()
+  private attributeValues = new Variables()
+  private setStatements: string[] = []
+  private removeStatements: string[] = []
+
+  set(attributePath: string[], value: string): this {
+    const attrPlaceholders = attributePath.map((attr) =>
+      this.addAttributeName(attr)
+    )
+    const valuePlaceholder = this.addAttributeValue(
+      attributePath[attributePath.length - 1],
+      value
+    )
+
+    this.setStatements.push(
+      `${attrPlaceholders.join(".")} = ${valuePlaceholder}`
+    )
+
+    return this
+  }
+
+  remove(attributePath: string[]): this {
+    const attrPlaceholders = attributePath.map((attr) =>
+      this.addAttributeName(attr)
+    )
+
+    this.removeStatements.push(attrPlaceholders.join("."))
+    return this
+  }
+
+  buildKeyConditionExpression<T extends TaggedModel>(
+    key: PartitionAndSortKey<T>
+  ): string {
+    const pkPlaceholder = this.addAttributeName(key.partitionKeyName)
+    const pkValuePlaceholder = this.addAttributeValue(
+      key.partitionKeyName,
+      key.partitionKey
+    )
+    const keyConditionExpression = [`${pkPlaceholder} = ${pkValuePlaceholder}`]
+
+    const { sortKeyName, sortKey } = key
+    const skPlaceholder = this.addAttributeName(sortKeyName)
+    const skValuePlaceholder = this.addAttributeValue(sortKeyName, sortKey)
+    keyConditionExpression.push(
+      `begins_with(${skPlaceholder}, ${skValuePlaceholder})`
+    )
+
+    return keyConditionExpression.join(" AND ")
+  }
+
+  build(): DynamoDBExpression {
+    const expression: string[] = []
+
+    if (this.setStatements.length > 0) {
+      expression.push("SET", this.setStatements.join(", "))
+    }
+
+    if (this.removeStatements.length > 0) {
+      expression.push("REMOVE", this.removeStatements.join(", "))
+    }
+
+    const attributeNames = this.attributeNames.getSubstitutions()
+    const attributeValues = this.attributeValues.getSubstitutions()
+    return {
+      expression: expression.join(" "),
+      attributeNames,
+      attributeValues,
+    }
+  }
+
+  protected addAttributeName(name: string): string {
+    return this.attributeNames.add(name)
+  }
+  protected addAttributeValue(name: string, value: any): string {
+    return this.attributeValues.add(name, value)
+  }
+}

--- a/src/main/dynamo/expressions/Variables.ts
+++ b/src/main/dynamo/expressions/Variables.ts
@@ -1,0 +1,13 @@
+export class Variables {
+  private substitutions: { [key: string]: string } = {}
+
+  add(name: string, value: any): string {
+    const placeholder = `:${name}`
+    this.substitutions[placeholder] = value
+    return placeholder
+  }
+
+  getSubstitutions(): Readonly<{ [key: string]: string }> {
+    return this.substitutions
+  }
+}

--- a/src/main/dynamo/updateItemProxy.ts
+++ b/src/main/dynamo/updateItemProxy.ts
@@ -1,18 +1,5 @@
 import { UpdateItemExpressionBuilder } from "./expressions/UpdateItemExpressionBuilder"
 
-type Author = {
-  id: string
-  name: string
-  book: Book
-  model: "Author"
-}
-
-type Book = {
-  id: string
-  title: string
-  model: "Book"
-}
-
 export function updateItemProxy<T extends {}>(
   expBuilder: UpdateItemExpressionBuilder,
   attrPath: string[] = []

--- a/src/main/dynamo/updateItemProxy.ts
+++ b/src/main/dynamo/updateItemProxy.ts
@@ -1,5 +1,8 @@
 import { UpdateItemExpressionBuilder } from "./expressions/UpdateItemExpressionBuilder"
 
+/** A recursive proxy used to dynamically build a DynamoDB update expression
+ *  as the proxied attributes are accessed and/or set.
+ */
 export function updateItemProxy<T extends {}>(
   expBuilder: UpdateItemExpressionBuilder,
   attrPath: string[] = []

--- a/src/main/dynamo/updateItemProxy.ts
+++ b/src/main/dynamo/updateItemProxy.ts
@@ -1,0 +1,38 @@
+import { UpdateItemExpressionBuilder } from "./expressions/UpdateItemExpressionBuilder"
+
+type Author = {
+  id: string
+  name: string
+  book: Book
+  model: "Author"
+}
+
+type Book = {
+  id: string
+  title: string
+  model: "Book"
+}
+
+export function updateItemProxy<T extends {}>(
+  expBuilder: UpdateItemExpressionBuilder,
+  attrPath: string[] = []
+): T {
+  return new Proxy({} as any, {
+    get(target, prop, receiver) {
+      attrPath.push(prop.toString())
+      return updateItemProxy<any>(expBuilder, attrPath)
+    },
+
+    set(target, prop, value) {
+      attrPath.push(prop.toString())
+      expBuilder.set(attrPath, value)
+      return true
+    },
+
+    deleteProperty(target, prop) {
+      attrPath.push(prop.toString())
+      expBuilder.remove(attrPath)
+      return true
+    },
+  })
+}

--- a/src/test/dynamo/Beyonce.test.ts
+++ b/src/test/dynamo/Beyonce.test.ts
@@ -21,6 +21,61 @@ describe("Beyonce", () => {
     await testPutAndRetrieveItem()
   })
 
+  it("should update a top-level item attribute", async () => {
+    const db = await setup()
+    const [musician, _, __] = aMusicianWithTwoSongs()
+    await db.put(musician)
+
+    const updated = await db.update(
+      MusicianModel.key({ id: musician.id }),
+      (musician) => {
+        musician.name = "Gary Moore"
+      }
+    )
+
+    expect(updated).toEqual({ ...musician, name: "Gary Moore" })
+
+    const reRead = await db.get(MusicianModel.key({ id: musician.id }))
+    expect(reRead).toEqual({ ...musician, name: "Gary Moore" })
+  })
+
+  it("should update a nested item attribute", async () => {
+    const db = await setup()
+    const [musician, _, __] = aMusicianWithTwoSongs()
+    await db.put(musician)
+
+    const updated = await db.update(
+      MusicianModel.key({ id: musician.id }),
+      (musician) => {
+        musician.details.description = "scottish blues dude"
+      }
+    )
+
+    expect(updated).toEqual({
+      ...musician,
+      details: { description: "scottish blues dude" },
+    })
+  })
+
+  it("should remove an item attribute", async () => {
+    const db = await setup()
+    const [m, _, __] = aMusicianWithTwoSongs()
+    const musician = { ...m, details: { description: "rasta man" } }
+    await db.put(musician)
+
+    const updated = await db.update(
+      MusicianModel.key({ id: musician.id }),
+      (musician) => {
+        delete musician.details.description
+      }
+    )
+
+    expect(updated).toEqual({
+      ...musician,
+      details: {},
+    })
+  })
+
   it("should support a consistentRead option on get", async () => {
     await setup()
     const [musician, _, __] = aMusicianWithTwoSongs()

--- a/src/test/dynamo/expressions/QueryExpressionBuilder.test.ts
+++ b/src/test/dynamo/expressions/QueryExpressionBuilder.test.ts
@@ -1,6 +1,8 @@
-import { ExpressionBuilder } from "../../main/dynamo/ExpressionBuilder"
-import { Musician } from "./models"
-import { Operator } from "../../main/dynamo/ExpressionBuilder"
+import {
+  QueryExpressionBuilder,
+  Operator,
+} from "../../../main/dynamo/expressions/QueryExpressionBuilder"
+import { Musician } from "../models"
 
 describe("ExpressionBuilder basic clauses", () => {
   it("doing nothing should yield blank expression", () => {
@@ -171,6 +173,6 @@ describe("ExpressionBuilder and/or attribute_(not)_exists clauses", () => {
   })
 })
 
-function exp(): ExpressionBuilder<Musician> {
-  return new ExpressionBuilder<Musician>()
+function exp(): QueryExpressionBuilder<Musician> {
+  return new QueryExpressionBuilder<Musician>()
 }

--- a/src/test/dynamo/models.ts
+++ b/src/test/dynamo/models.ts
@@ -15,6 +15,9 @@ export interface Musician {
   model: ModelType.Musician
   id: string
   name: string
+  details: {
+    description?: string
+  }
 }
 
 export interface Song {
@@ -53,6 +56,9 @@ export function aMusicianWithTwoSongs(): [Musician, Song, Song] {
   const musician = MusicianModel.create({
     id: "1",
     name: "Bob Marley",
+    details: {
+      description: "rasta man",
+    },
   })
 
   const song1 = SongModel.create({


### PR DESCRIPTION
This PR adds functionality to support partial updates of Dynamo items. For context, here are the new docs:

Beyoncé supports type-safe partial updates on items, without having to read the item from the db first. And it works, even through nested attributes:

```TypeScript
const updatedAuthor = await beyonce.update(AuthorModel.key({ id: "1" }), (author) => {
  author.name = "Jack London",
  author.details.description = "American novelist"
  delete author.details.someDeprecatedField
})
```

Here `author` is an intelligent proxy object (thus we avoid having to read the full item from the DB prior to updating it).And `beyonce.update(...)` returns the full `Author`, with the updated fields

Fixes: #27 and #25 