### PR TITLE
[Beyonce]: Allow Compound Partition/Sort Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Tables:
 
 #### A note on `partitionKey` and `sortKey` syntax
 
-Beyonce expects you to specify your partition and sort keys as tuple-2s, e.g. `[Author, $id]`. The first element is a "key prefix" and the 2nd must be a field on your model. For example we set the primary key of the `Author` model above to: `[Author, $id]`, would result in the key: `Author-$id`, where `$id` is the value of a specific Author's id.
+Beyonce expects you to specify your partition and sort keys as arrays, e.g. `[Author, $id]`. The first element is a "key prefix" and all subsequent items must be field names on your model. For example we set the primary key of the `Author` model above to: `[Author, $id]`, would result in the key: `Author-$id`, where `$id` is the value of a specific Author's id. And if we wanted a compound key we could do `[Author, $id, $name]`. You can specify compound keys for both partition and sort keys.
 
 Using the example above, if we wanted to place `Books` under the same partition key, then we'd need to set the `Book` model's `partitionKey` to `[Author, $authorId]`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ginger.io/beyonce",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "description": "Type-safe DynamoDB query builder for TypeScript. Designed with single-table architecture in mind.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/main/codegen/generateModels.ts
+++ b/src/main/codegen/generateModels.ts
@@ -1,16 +1,20 @@
 import { Model } from "./types"
+import { formatKeyComponent } from "./util"
 
 export function generateModels(models: Model[]) {
   return models.map(generateModel)
 }
 
 function generateModel(model: Model): string {
-  const [pkPrefix, pk] = model.keys.partitionKey
-  const [skPrefix, sk] = model.keys.sortKey
+  const [pkPrefix, ...pkComponents] = model.keys.partitionKey.map(
+    formatKeyComponent
+  )
+
+  const [skPrefix, ...skComponents] = model.keys.sortKey.map(formatKeyComponent)
 
   return `export const ${model.name}Model = ${model.tableName}Table
     .model<${model.name}>(ModelType.${model.name})
-    .partitionKey("${pkPrefix}", "${pk.replace("$", "")}")
-    .sortKey("${skPrefix}", "${sk.replace("$", "")}")
+    .partitionKey(${pkPrefix}, ${pkComponents.join(", ")})
+    .sortKey(${skPrefix}, ${skComponents.join(", ")})
   `
 }

--- a/src/main/codegen/types.ts
+++ b/src/main/codegen/types.ts
@@ -17,7 +17,7 @@ export type PartitionDefinition = {
 }
 
 export type ModelDefinition = Keys & Fields
-export type Keys = { partitionKey: [string, string]; sortKey: [string, string] }
+export type Keys = { partitionKey: string[]; sortKey: string[] }
 export type Fields = { [fieldName: string]: string }
 
 export type GSIDefinition = {

--- a/src/main/codegen/util.ts
+++ b/src/main/codegen/util.ts
@@ -11,3 +11,7 @@ export function groupBy<T extends { [key: string]: any }, U extends keyof T>(
 
   return Object.entries(groupedItems)
 }
+
+export function formatKeyComponent(component: string): string {
+  return `"${component.replace("$", "")}"`
+}

--- a/src/test/codegen/generateCode.test.ts
+++ b/src/test/codegen/generateCode.test.ts
@@ -176,7 +176,7 @@ export const MusiciansPartition = MusicTable.partition([MusicianModel])
 `)
 })
 
-it("should generate table, add partition and sork key to encryption blacklist", () => {
+it("should generate table, add partition and sort key to encryption blacklist", () => {
   const result = generateCode(`
 Tables:
   Library:

--- a/src/test/codegen/generateCode.test.ts
+++ b/src/test/codegen/generateCode.test.ts
@@ -322,3 +322,49 @@ Tables:
 
   expect(lines).toContainEqual(`name: BestNameEvah`)
 })
+
+it("should generate a complex key model", () => {
+  const result = generateCode(`
+Tables:
+  ComplexLibrary:
+    Partitions:
+      ComplexAuthors:
+        ComplexAuthor:
+          partitionKey: [Author, $id]
+          sortKey: [Author, $id, $name]
+          id: string
+          name: string
+`)
+
+  expect(result).toEqual(`import { Table } from "@ginger.io/beyonce"
+
+export const ComplexLibraryTable = new Table({
+  name: "ComplexLibrary",
+  partitionKeyName: "pk",
+  sortKeyName: "sk",
+  encryptionBlacklist: ["id", "name"]
+})
+
+export enum ModelType {
+  ComplexAuthor = "ComplexAuthor"
+}
+
+export interface ComplexAuthor {
+  model: ModelType.ComplexAuthor
+  id: string
+  name: string
+}
+
+export const ComplexAuthorModel = ComplexLibraryTable.model<ComplexAuthor>(
+  ModelType.ComplexAuthor
+)
+  .partitionKey("Author", "id")
+  .sortKey("Author", "id", "name")
+
+export type Model = ComplexAuthor
+
+export const ComplexAuthorsPartition = ComplexLibraryTable.partition([
+  ComplexAuthorModel
+])
+`)
+})

--- a/src/test/dynamo/models.ts
+++ b/src/test/dynamo/models.ts
@@ -9,7 +9,6 @@ export const table = new Table({
 export enum ModelType {
   Musician = "musician",
   Song = "song",
-  Album = "album",
 }
 
 export interface Musician {

--- a/src/test/dynamo/models.ts
+++ b/src/test/dynamo/models.ts
@@ -9,6 +9,7 @@ export const table = new Table({
 export enum ModelType {
   Musician = "musician",
   Song = "song",
+  Album = "album",
 }
 
 export interface Musician {


### PR DESCRIPTION
@cjoelrun  started this work during our last hackday in: https://github.com/ginger-io/beyonce/pull/33. This PR splits off an incremental chunk of that work so we can merge a useful feature in. 

Previously, Beyonce would force you to structure your partition / sort keys as a tuple-2 composed of [prefix, modelFieldName]. But there are many use-cases in Dynamo where you'd want to have a "compound" key -- i.e. a key formed from not 1, but multiple fields on the model. 

As an example, we might have: 

1. A model for `SalesRep`, where our pk is `["SalesRep", "$id"]`.
2. An `Sale` model that has the same partition key as the rep it's attached to and a sort key that's like `[Sale, "$country", "$state", "$city"]`. 

The compound key in 2) would allow us to query for all sales by a rep in a given country, state or city (by using the `begins_with` key condition in our query operations). 

Another use-case: it's common to "invert" a table's keys using a Global Secondary Index (i.e. flip the pk and sk). Using a compound key in the sk  is often useful there to ensure that when you swap the keys, a ton of data doesn't wind up in a single partition. As a concrete example, we might have: 

1. An `Item` model with pk: `["Item", "$id"]` and sk: `["Item", "$id", "$version"]` (<-- note the compound key here)
2. A `Tag` model with pk: `["Item", "$itemId"]` and sk: `["Tag", "$name"]`

So now, we can `.query(...)` with an item's partition key to get it + its tags. But we'd need to swap the keys in a GSI to query the other side of the relationship -- i.e. "here's a tag, give me all the items with that tag".

If we didn't use the compound key in 1) and just used : `["Item", "$version"]`  -- when we flipped the pk / sk in our GSI, we'd end up with massive partitions. All items with the same version number would wind up in the same partition -- which would be ... not good :). 