### PR TITLE
Add test for compound key model generation

### DIFF
--- a/src/test/codegen/generateCode.test.ts
+++ b/src/test/codegen/generateCode.test.ts
@@ -322,3 +322,49 @@ Tables:
 
   expect(lines).toContainEqual(`name: BestNameEvah`)
 })
+
+it("should generate a complex key model", () => {
+  const result = generateCode(`
+Tables:
+  ComplexLibrary:
+    Partitions:
+      ComplexAuthors:
+        ComplexAuthor:
+          partitionKey: [Author, $id]
+          sortKey: [Author, $id, $name]
+          id: string
+          name: string
+`)
+
+  expect(result).toEqual(`import { Table } from "@ginger.io/beyonce"
+
+export const ComplexLibraryTable = new Table({
+  name: "ComplexLibrary",
+  partitionKeyName: "pk",
+  sortKeyName: "sk",
+  encryptionBlacklist: ["id", "name"]
+})
+
+export enum ModelType {
+  ComplexAuthor = "ComplexAuthor"
+}
+
+export interface ComplexAuthor {
+  model: ModelType.ComplexAuthor
+  id: string
+  name: string
+}
+
+export const ComplexAuthorModel = ComplexLibraryTable.model<ComplexAuthor>(
+  ModelType.ComplexAuthor
+)
+  .partitionKey("Author", "id")
+  .sortKey("Author", "id", "name")
+
+export type Model = ComplexAuthor
+
+export const ComplexAuthorsPartition = ComplexLibraryTable.partition([
+  ComplexAuthorModel
+])
+`)
+})


### PR DESCRIPTION
I think there may be an issue with the encryptionBlacklist not grabbing all the keys in the compound key. Adding this test from my other PR.