### PR TITLE
[Beyonce]: Add support for parallel scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,33 @@ for await (const { items } of iterator) {
 }
 ```
 
+#### Parallel Scans
+
+You can perform "parallel scans" by passing a `parallelScan` config operation to the `.scan` method,
+like so:
+
+```TypeScript
+// Somewhere inside of Worker 1
+const segment1 = beyonce
+  .scan({ parallelScan: { segmentId: 0, totalSegments: 2 }})
+  .iterator()
+
+for await (const results of segment1) {
+  // ...
+}
+
+// Somewhere inside of Worker 2
+const segment2 = beyonce
+  .scan({ parallelScan: { segmentId: 1, totalSegments: 2 }})
+  .iterator()
+
+for await (const results of segment2) {
+  // ...
+}
+```
+
+These options mirror the underlying [DynamoDB API](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.ParallelScan)
+
 ### BatchGet
 
 ```TypeScript

--- a/README.md
+++ b/README.md
@@ -276,13 +276,13 @@ for await (const { items } of iterator) {
 
 #### Parallel Scans
 
-You can perform "parallel scans" by passing a `parallelScan` config operation to the `.scan` method,
+You can perform "parallel scans" by passing a `parallel` config operation to the `.scan` method,
 like so:
 
 ```TypeScript
 // Somewhere inside of Worker 1
 const segment1 = beyonce
-  .scan({ parallelScan: { segmentId: 0, totalSegments: 2 }})
+  .scan({ parallel: { segmentId: 0, totalSegments: 2 }})
   .iterator()
 
 for await (const results of segment1) {

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ for await (const results of segment1) {
 
 // Somewhere inside of Worker 2
 const segment2 = beyonce
-  .scan({ parallelScan: { segmentId: 1, totalSegments: 2 }})
+  .scan({ parallel: { segmentId: 1, totalSegments: 2 }})
   .iterator()
 
 for await (const results of segment2) {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,15 @@
 {
   "name": "@ginger.io/beyonce",
-  "version": "0.0.43",
+  "version": "0.0.46",
   "description": "Type-safe DynamoDB query builder for TypeScript. Designed with single-table architecture in mind.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
     "beyonce": "dist/codegen/cli.js"
   },
+  "files": [
+    "./dist"
+  ],
   "dependencies": {
     "@ginger.io/jay-z": "0.0.8",
     "aws-sdk": "^2.760.0",

--- a/src/main/dynamo/Beyonce.ts
+++ b/src/main/dynamo/Beyonce.ts
@@ -9,7 +9,7 @@ import {
   PartitionKeyAndSortKeyPrefix,
 } from "./keys"
 import { QueryBuilder } from "./QueryBuilder"
-import { ScanBuilder } from "./ScanBuilder"
+import { ParallelScanConfig, ScanBuilder } from "./ScanBuilder"
 import { Table } from "./Table"
 import { ExtractKeyType, GroupedModels, TaggedModel } from "./types"
 import { updateItemProxy } from "./updateItemProxy"
@@ -36,6 +36,7 @@ export type QueryOptions = {
 
 export type ScanOptions = {
   consistentRead?: boolean
+  parallelScan?: ParallelScanConfig
 }
 
 /** A thin wrapper around the DynamoDB sdk client that

--- a/src/main/dynamo/Beyonce.ts
+++ b/src/main/dynamo/Beyonce.ts
@@ -36,7 +36,7 @@ export type QueryOptions = {
 
 export type ScanOptions = {
   consistentRead?: boolean
-  parallelScan?: ParallelScanConfig
+  parallel?: ParallelScanConfig
 }
 
 /** A thin wrapper around the DynamoDB sdk client that

--- a/src/main/dynamo/ScanBuilder.ts
+++ b/src/main/dynamo/ScanBuilder.ts
@@ -17,6 +17,12 @@ type ScanConfig<T extends TaggedModel> = {
   table: Table
   jayz?: JayZ
   consistentRead?: boolean
+  parallelScan?: ParallelScanConfig
+}
+
+export type ParallelScanConfig = {
+  segmentId: number // 0-indexed -- i.e. first segment id is 0, not 1
+  totalSegments: number
 }
 
 /** Builds and executes parameters for a DynamoDB Scan operation */
@@ -64,7 +70,7 @@ export class ScanBuilder<T extends TaggedModel> extends QueryExpressionBuilder<
   private buildScan(
     options: IteratorOptions
   ): DynamoDB.DocumentClient.ScanInput {
-    const { table, consistentRead } = this.config
+    const { table, consistentRead, parallelScan } = this.config
     const { expression, attributeNames, attributeValues } = this.build()
     const filterExp = expression !== "" ? expression : undefined
 
@@ -84,6 +90,8 @@ export class ScanBuilder<T extends TaggedModel> extends QueryExpressionBuilder<
       FilterExpression: filterExp,
       ExclusiveStartKey: options.cursor,
       Limit: options.pageSize,
+      Segment: parallelScan?.segmentId,
+      TotalSegments: parallelScan?.totalSegments,
     }
   }
 }

--- a/src/main/dynamo/ScanBuilder.ts
+++ b/src/main/dynamo/ScanBuilder.ts
@@ -17,7 +17,7 @@ type ScanConfig<T extends TaggedModel> = {
   table: Table
   jayz?: JayZ
   consistentRead?: boolean
-  parallelScan?: ParallelScanConfig
+  parallel?: ParallelScanConfig
 }
 
 export type ParallelScanConfig = {
@@ -70,7 +70,7 @@ export class ScanBuilder<T extends TaggedModel> extends QueryExpressionBuilder<
   private buildScan(
     options: IteratorOptions
   ): DynamoDB.DocumentClient.ScanInput {
-    const { table, consistentRead, parallelScan } = this.config
+    const { table, consistentRead, parallel } = this.config
     const { expression, attributeNames, attributeValues } = this.build()
     const filterExp = expression !== "" ? expression : undefined
 
@@ -90,8 +90,8 @@ export class ScanBuilder<T extends TaggedModel> extends QueryExpressionBuilder<
       FilterExpression: filterExp,
       ExclusiveStartKey: options.cursor,
       Limit: options.pageSize,
-      Segment: parallelScan?.segmentId,
-      TotalSegments: parallelScan?.totalSegments,
+      Segment: parallel?.segmentId,
+      TotalSegments: parallel?.totalSegments,
     }
   }
 }

--- a/src/test/dynamo/query.test.ts
+++ b/src/test/dynamo/query.test.ts
@@ -8,7 +8,7 @@ import {
   Song,
   SongModel,
 } from "./models"
-import { createJayZ, setup } from "./util"
+import { createJayZ, createSongs, setup } from "./util"
 
 describe("Beyonce.query", () => {
   it("should return empty arrays when no models found when querying", async () => {
@@ -121,22 +121,7 @@ async function testEmptyQuery(jayZ?: JayZ) {
 
 async function testQueryWithPaginatedResults(jayZ?: JayZ) {
   const db = await setup(jayZ)
-
-  // DynamoDB has a 400kb Item limit w/ a 1MB response size limit
-  // Thus the following items comprise at least 100kb * 25 = ~2.5MB of data
-  // i.e. at least 3 pages. Note that data encrypted with JayZ is significantly larger
-  const mp3 = crypto.randomBytes(100_000)
-  const songs: Song[] = [...Array(25).keys()].map((songId) =>
-    SongModel.create({
-      musicianId: "1",
-      id: songId.toString(),
-      title: `Song ${songId}`,
-      mp3,
-    })
-  )
-
-  await Promise.all(songs.map((song) => db.put(song)))
-
+  const songs = await createSongs(db)
   const results = await db.query(MusicianPartition.key({ id: "1" })).exec()
   expect(results.song.length).toEqual(songs.length)
 }

--- a/src/test/dynamo/scan.test.ts
+++ b/src/test/dynamo/scan.test.ts
@@ -79,11 +79,11 @@ async function testParallelScan(jayZ?: JayZ) {
   const songs = await createSongs(db)
 
   const segment1 = db
-    .scan<Song>({ parallelScan: { segmentId: 0, totalSegments: 2 } })
+    .scan<Song>({ parallel: { segmentId: 0, totalSegments: 2 } })
     .iterator()
 
   const segment2 = db
-    .scan<Song>({ parallelScan: { segmentId: 1, totalSegments: 2 } })
+    .scan<Song>({ parallel: { segmentId: 1, totalSegments: 2 } })
     .iterator()
 
   const results: Song[] = []

--- a/src/test/dynamo/util.ts
+++ b/src/test/dynamo/util.ts
@@ -1,7 +1,8 @@
 import { FixedDataKeyProvider, JayZ } from "@ginger.io/jay-z"
 import { DynamoDB } from "aws-sdk"
+import crypto from "crypto"
 import { Beyonce } from "../../main/dynamo/Beyonce"
-import { table } from "./models"
+import { Song, SongModel, table } from "./models"
 
 export const port = 8000
 const isRunningOnCI = process.env.CI_BUILD_ID !== undefined
@@ -36,4 +37,24 @@ export async function setup(jayz?: JayZ): Promise<Beyonce> {
 export async function createJayZ(): Promise<JayZ> {
   const keyProvider = await FixedDataKeyProvider.forLibsodium()
   return new JayZ({ keyProvider })
+}
+
+// DynamoDB has a 400kb Item limit w/ a 1MB response size limit
+// Thus 25 song items comprise at least 100kb * 25 = ~2.5MB of data
+// i.e. at least 3 pages. Note that data encrypted with JayZ is significantly larger
+export async function createSongs(
+  db: Beyonce,
+  n: number = 25
+): Promise<Song[]> {
+  const mp3 = crypto.randomBytes(100_000)
+  const songs: Song[] = [...Array(n).keys()].map((songId) =>
+    SongModel.create({
+      musicianId: "1",
+      id: songId.toString(),
+      title: `Song ${songId}`,
+      mp3,
+    })
+  )
+  await Promise.all(songs.map((song) => db.put(song)))
+  return songs
 }


### PR DESCRIPTION
This PR builds off of #42  and adds parallel scan functionality, so users can break their table into N segments and scan each in parallel. 

```TypeScript
// Somewhere inside of Worker 1
const segment1 = beyonce
  .scan({ parallel: { segmentId: 0, totalSegments: 2 }})
  .iterator()

for await (const results of segment1) {
  // ...
}

// Somewhere inside of Worker 2
const segment2 = beyonce
  .scan({ parallel: { segmentId: 1, totalSegments: 2 }})
  .iterator()

for await (const results of segment2) {
  // ...
}
```