### PR TITLE
[Beyonce]: Fix a bug where you couldn't use the same attribute name multiple times in queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ginger.io/beyonce",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "description": "Type-safe DynamoDB query builder for TypeScript. Designed with single-table architecture in mind.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/main/dynamo/ScanBuilder.ts
+++ b/src/main/dynamo/ScanBuilder.ts
@@ -78,7 +78,7 @@ export class ScanBuilder<T extends TaggedModel> extends QueryExpressionBuilder<
     const includeAttributeValues =
       filterExp !== undefined && Object.values(attributeValues).length > 0
 
-    return {
+    const scan = {
       TableName: table.tableName,
       ConsistentRead: consistentRead,
       ExpressionAttributeNames: includeAttributeNames
@@ -93,5 +93,8 @@ export class ScanBuilder<T extends TaggedModel> extends QueryExpressionBuilder<
       Segment: parallel?.segmentId,
       TotalSegments: parallel?.totalSegments,
     }
+
+    this.reset()
+    return scan
   }
 }

--- a/src/main/dynamo/expressions/Attributes.ts
+++ b/src/main/dynamo/expressions/Attributes.ts
@@ -7,7 +7,7 @@ export class Attributes {
     return placeholder
   }
 
-  getSubstitutions(): Readonly<{ [key: string]: string }> {
-    return this.substitutions
+  getSubstitutions(): { [key: string]: string } {
+    return { ...this.substitutions }
   }
 }

--- a/src/main/dynamo/expressions/QueryExpressionBuilder.ts
+++ b/src/main/dynamo/expressions/QueryExpressionBuilder.ts
@@ -63,26 +63,33 @@ export class QueryExpressionBuilder<T extends TaggedModel> {
     return this
   }
 
+  build(): DynamoDBExpression {
+    const expression = this.statements.join(" ")
+    const attributeNames = this.attributeNames.getSubstitutions()
+    const attributeValues = this.attributeValues.getSubstitutions()
+
+    return {
+      expression,
+      attributeNames,
+      attributeValues,
+    }
+  }
+
   protected addAttributeName(name: string): string {
     return this.attributeNames.add(name)
   }
-  protected addAttributeValue(name: string, value: any): string {
-    return this.attributeValues.add(name, value)
+  protected addAttributeValue(value: any): string {
+    return this.attributeValues.add(value)
   }
 
   protected addStatement(statement: string): void {
     this.statements.push(statement)
   }
 
-  build(): DynamoDBExpression {
-    const expression = this.statements.join(" ")
-    const attributeNames = this.attributeNames.getSubstitutions()
-    const attributeValues = this.attributeValues.getSubstitutions()
-    return {
-      expression,
-      attributeNames,
-      attributeValues,
-    }
+  protected reset(): void {
+    this.attributeNames = new Attributes()
+    this.attributeValues = new Variables()
+    this.statements = []
   }
 
   private addCondition(params: {
@@ -92,10 +99,7 @@ export class QueryExpressionBuilder<T extends TaggedModel> {
     booleanOperator?: "OR" | "AND"
   }): void {
     const attributePlaceholder = this.addAttributeName(params.attribute)
-    const valuePlaceholder = this.addAttributeValue(
-      params.attribute,
-      params.value
-    )
+    const valuePlaceholder = this.addAttributeValue(params.value)
     const expression = []
 
     if (params.booleanOperator !== undefined) {

--- a/src/main/dynamo/expressions/UpdateItemExpressionBuilder.ts
+++ b/src/main/dynamo/expressions/UpdateItemExpressionBuilder.ts
@@ -14,10 +14,7 @@ export class UpdateItemExpressionBuilder {
     const attrPlaceholders = attributePath.map((attr) =>
       this.addAttributeName(attr)
     )
-    const valuePlaceholder = this.addAttributeValue(
-      attributePath[attributePath.length - 1],
-      value
-    )
+    const valuePlaceholder = this.addAttributeValue(value)
 
     this.setStatements.push(
       `${attrPlaceholders.join(".")} = ${valuePlaceholder}`
@@ -39,15 +36,12 @@ export class UpdateItemExpressionBuilder {
     key: PartitionAndSortKey<T>
   ): string {
     const pkPlaceholder = this.addAttributeName(key.partitionKeyName)
-    const pkValuePlaceholder = this.addAttributeValue(
-      key.partitionKeyName,
-      key.partitionKey
-    )
+    const pkValuePlaceholder = this.addAttributeValue(key.partitionKey)
     const keyConditionExpression = [`${pkPlaceholder} = ${pkValuePlaceholder}`]
 
     const { sortKeyName, sortKey } = key
     const skPlaceholder = this.addAttributeName(sortKeyName)
-    const skValuePlaceholder = this.addAttributeValue(sortKeyName, sortKey)
+    const skValuePlaceholder = this.addAttributeValue(sortKey)
     keyConditionExpression.push(
       `begins_with(${skPlaceholder}, ${skValuePlaceholder})`
     )
@@ -78,7 +72,7 @@ export class UpdateItemExpressionBuilder {
   protected addAttributeName(name: string): string {
     return this.attributeNames.add(name)
   }
-  protected addAttributeValue(name: string, value: any): string {
-    return this.attributeValues.add(name, value)
+  protected addAttributeValue(value: any): string {
+    return this.attributeValues.add(value)
   }
 }

--- a/src/main/dynamo/expressions/Variables.ts
+++ b/src/main/dynamo/expressions/Variables.ts
@@ -1,13 +1,15 @@
 export class Variables {
   private substitutions: { [key: string]: string } = {}
+  private counter = 1
 
-  add(name: string, value: any): string {
-    const placeholder = `:${name}`
+  add(value: any): string {
+    const placeholder = `:v${this.counter}`
     this.substitutions[placeholder] = value
+    this.counter += 1
     return placeholder
   }
 
-  getSubstitutions(): Readonly<{ [key: string]: string }> {
-    return this.substitutions
+  getSubstitutions(): { [key: string]: string } {
+    return { ...this.substitutions }
   }
 }

--- a/src/test/dynamo/expressions/QueryExpressionBuilder.test.ts
+++ b/src/test/dynamo/expressions/QueryExpressionBuilder.test.ts
@@ -20,9 +20,9 @@ describe("ExpressionBuilder basic clauses", () => {
       .build()
 
     expect(result).toEqual({
-      expression: "#name = :name",
+      expression: "#name = :v1",
       attributeNames: { "#name": "name" },
-      attributeValues: { ":name": "Bob Marley" },
+      attributeValues: { ":v1": "Bob Marley" },
     })
   })
 
@@ -34,9 +34,9 @@ describe("ExpressionBuilder basic clauses", () => {
         .build()
 
       expect(result).toEqual({
-        expression: `#name ${operator} :name`,
+        expression: `#name ${operator} :v1`,
         attributeNames: { "#name": "name" },
-        attributeValues: { ":name": "Bob Marley" },
+        attributeValues: { ":v1": "Bob Marley" },
       })
     })
   })
@@ -48,7 +48,7 @@ describe("ExpressionBuilder basic clauses", () => {
       .build()
 
     expect(result).toEqual({
-      expression: "#name = :name OR #id <> :id",
+      expression: "#name = :v1 OR #id <> :v2",
 
       attributeNames: {
         "#name": "name",
@@ -56,8 +56,28 @@ describe("ExpressionBuilder basic clauses", () => {
       },
 
       attributeValues: {
-        ":name": "Bob Marley",
-        ":id": "123",
+        ":v1": "Bob Marley",
+        ":v2": "123",
+      },
+    })
+  })
+
+  it("should support using the same attribute name multiple times", () => {
+    const result = exp()
+      .where("name", "=", "Bob Marley")
+      .or("name", "=", "Flea")
+      .build()
+
+    expect(result).toEqual({
+      expression: "#name = :v1 OR #name = :v2",
+
+      attributeNames: {
+        "#name": "name",
+      },
+
+      attributeValues: {
+        ":v1": "Bob Marley",
+        ":v2": "Flea",
       },
     })
   })
@@ -69,7 +89,7 @@ describe("ExpressionBuilder basic clauses", () => {
       .build()
 
     expect(result).toEqual({
-      expression: "#name = :name AND #id <> :id",
+      expression: "#name = :v1 AND #id <> :v2",
 
       attributeNames: {
         "#name": "name",
@@ -77,8 +97,8 @@ describe("ExpressionBuilder basic clauses", () => {
       },
 
       attributeValues: {
-        ":name": "Bob Marley",
-        ":id": "123",
+        ":v1": "Bob Marley",
+        ":v2": "123",
       },
     })
   })
@@ -117,7 +137,7 @@ describe("ExpressionBuilder and/or attribute_(not)_exists clauses", () => {
   }
 
   const attributeValues = {
-    ":name": "Bob Marley",
+    ":v1": "Bob Marley",
   }
 
   it("should support orAttributeExists clauses", () => {
@@ -127,7 +147,7 @@ describe("ExpressionBuilder and/or attribute_(not)_exists clauses", () => {
       .build()
 
     expect(result).toEqual({
-      expression: "#name = :name OR attribute_exists(#id)",
+      expression: "#name = :v1 OR attribute_exists(#id)",
       attributeNames,
       attributeValues,
     })
@@ -140,7 +160,7 @@ describe("ExpressionBuilder and/or attribute_(not)_exists clauses", () => {
       .build()
 
     expect(result).toEqual({
-      expression: "#name = :name AND attribute_exists(#id)",
+      expression: "#name = :v1 AND attribute_exists(#id)",
       attributeNames,
       attributeValues,
     })
@@ -153,7 +173,7 @@ describe("ExpressionBuilder and/or attribute_(not)_exists clauses", () => {
       .build()
 
     expect(result).toEqual({
-      expression: "#name = :name OR attribute_not_exists(#id)",
+      expression: "#name = :v1 OR attribute_not_exists(#id)",
       attributeNames,
       attributeValues,
     })
@@ -166,7 +186,7 @@ describe("ExpressionBuilder and/or attribute_(not)_exists clauses", () => {
       .build()
 
     expect(result).toEqual({
-      expression: "#name = :name AND attribute_not_exists(#id)",
+      expression: "#name = :v1 AND attribute_not_exists(#id)",
       attributeNames,
       attributeValues,
     })

--- a/src/test/dynamo/query.test.ts
+++ b/src/test/dynamo/query.test.ts
@@ -1,11 +1,9 @@
 import { JayZ } from "@ginger.io/jay-z"
-import crypto from "crypto"
 import {
   aMusicianWithTwoSongs,
   ModelType,
   MusicianModel,
   MusicianPartition,
-  Song,
   SongModel,
 } from "./models"
 import { createJayZ, createSongs, setup } from "./util"


### PR DESCRIPTION
This PR fixes a bug that @cjoelrun encountered where if you had a query that used an attribute name multiple times with different values, like: 

```TypeScript
 beyonce
  .query(...)
  .where("model", "=", Model.Foo)
  .or("model", "=", Model.Boo)
```

Then only the last value provided would be used. 

The root cause was we were using the attribute's name as the key in the [ExpressionAttributeValues](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ExpressionAttributeValues.html) map passed to DynamoDB. And as a result, it was always last write wins. 

This PR fixes that bug by using an auto-incrementing values map, e.g. `:v1` => `Model.foo`, `:v2` => `Model.boo`. 