### PR TITLE
[Beyonce]: Rework structure of YAML file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,5 @@ RUN apk add --update \
     python-dev \
     py-pip \
     build-base \
-    nodejs=12.15.0-r1 \
-    npm=12.15.0-r1
+    nodejs \
+    npm

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ginger.io/beyonce",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "description": "Type-safe DynamoDB query builder for TypeScript. Designed with single-table architecture in mind.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/main/codegen/generateGSIs.ts
+++ b/src/main/codegen/generateGSIs.ts
@@ -1,4 +1,4 @@
-import { Fields, Table } from "./types"
+import { ModelDefinition, Table } from "./types"
 
 export function generateGSIs(tables: Table[]): string {
   return tables.map(generateGSIsForTable).join("\n\n")
@@ -6,13 +6,13 @@ export function generateGSIs(tables: Table[]): string {
 
 function generateGSIsForTable(table: Table): string {
   const fieldToModels: { [fieldName: string]: string[] } = {
-    model: [],
+    model: []
   }
 
-  const fieldsAllModelsHave: Fields = {
+  const fieldsAllModelsHave: ModelDefinition = {
     [table.partitionKeyName]: "string",
     [table.sortKeyName]: "string",
-    model: "string",
+    model: "string"
   }
 
   table.partitions.forEach((partition) => {

--- a/src/main/codegen/types.ts
+++ b/src/main/codegen/types.ts
@@ -1,24 +1,30 @@
 export type YAMLFile = {
-  Tables: {
+  tables: {
     [tableName: string]: TableDefinition
   }
 }
 
 export type TableDefinition = {
-  Partitions: {
+  models: {
+    [modelName: string]: ModelDefinition
+  }
+
+  partitions: {
     [partitionName: string]: PartitionDefinition
   }
 
-  GSIs?: { [indexName: string]: GSIDefinition }
+  gsis?: { [indexName: string]: GSIDefinition }
 }
 
 export type PartitionDefinition = {
-  [modelName: string]: ModelDefinition
+  partitionKeyPrefix: string
+  models: {
+    [modelName: string]: ModelKeys
+  }
 }
 
-export type ModelDefinition = Keys & Fields
-export type Keys = { partitionKey: string[]; sortKey: string[] }
-export type Fields = { [fieldName: string]: string }
+export type ModelKeys = { partitionKey: string[]; sortKey: string[] }
+export type ModelDefinition = { [fieldName: string]: string }
 
 export type GSIDefinition = {
   partitionKey: string
@@ -49,6 +55,6 @@ export type Model = {
   tableName: string
   partitionName: string
   name: string
-  keys: Keys
-  fields: Fields
+  keys: ModelKeys
+  fields: ModelDefinition
 }

--- a/src/test/codegen/generateCode.test.ts
+++ b/src/test/codegen/generateCode.test.ts
@@ -2,15 +2,19 @@ import { generateCode } from "../../main/codegen/generateCode"
 
 it("should generate a simple model", () => {
   const result = generateCode(`
-Tables:
+tables:
   Library:
-    Partitions:
+    models:
+      Author:
+        id: string
+        name: string 
+    partitions:
       Authors:
-        Author:
-          partitionKey: [Author, $id]
-          sortKey: [Author, $id]
-          id: string
-          name: string
+        partitionKeyPrefix: Author
+        models:
+          Author:
+            partitionKey: [$id]
+            sortKey: [Author, $id]
 `)
 
   expect(result).toEqual(`import { Table } from "@ginger.io/beyonce"
@@ -44,22 +48,29 @@ export const AuthorsPartition = LibraryTable.partition([AuthorModel])
 
 it("should generate two models", () => {
   const result = generateCode(`
-Tables:
+tables:
   Library:
-    Partitions:
-      Authors:
-        Author:
-          partitionKey: [Author, $id]
-          sortKey: [Author, $id]
-          id: string
-          name: string
+    models:
+      Author:
+        id: string
+        name: string
+      
+      Book:
+        id: string
+        authorId: string
+        name: string
 
-        Book:
-          partitionKey: [Author, $authorId]
-          sortKey: [Book, $id]
-          id: string
-          authorId: string
-          name: string
+    partitions:
+      Authors:
+        partitionKeyPrefix: Author
+        models:
+          Author:
+            partitionKey: [$id]
+            sortKey: [Author, $id]
+
+          Book:
+            partitionKey: [$authorId]
+            sortKey: [Book, $id]
 `)
 
   expect(result).toEqual(`import { Table } from "@ginger.io/beyonce"
@@ -105,25 +116,36 @@ export const AuthorsPartition = LibraryTable.partition([AuthorModel, BookModel])
 
 it("should generate multiple tables with simple models", () => {
   const result = generateCode(`
-Tables:
+tables:
   Library:
-    Partitions:
+    models:
+      Author:
+        id: string
+        name: string
+        userId: string
+
+    partitions:
       Authors:
-        Author:
-          partitionKey: [Author, $id]
-          sortKey: [Author, $userId]
-          id: string
-          name: string
-          userId: string
+        partitionKeyPrefix: Author
+        models:
+          Author:
+            partitionKey: [$id]
+            sortKey: [Author, $userId]
+          
   Music:
-    Partitions:
+    models:
+      Musician:
+        id: string
+        name: string
+        musicianId: string
+
+    partitions:
       Musicians:
-        Musician:
-          partitionKey: [Musician, $id]
-          sortKey: [Musician, $musicianId]
-          id: string
-          name: string
-          musicianId: string
+        partitionKeyPrefix: Musician
+        models:
+          Musician:
+            partitionKey: [$id]
+            sortKey: [Musician, $musicianId]
 `)
 
   expect(result).toEqual(`import { Table } from "@ginger.io/beyonce"
@@ -178,23 +200,30 @@ export const MusiciansPartition = MusicTable.partition([MusicianModel])
 
 it("should generate table, add partition and sort key to encryption blacklist", () => {
   const result = generateCode(`
-Tables:
+tables:
   Library:
-    Partitions:
+    models:
+      Author:
+        id: string
+        name: string
+      
+      Book:
+        id: string
+        name: string
+
+    partitions:
       Authors:
-        Author:
-          partitionKey: [Author, $id]
-          sortKey: [Author, $id]
-          id: string
-          name: string
+        partitionKeyPrefix: Author
+        models: 
+          Author:
+            partitionKey: [$id]
+            sortKey: [Author, $id]
 
-        Book:
-          partitionKey: [Author, $id]
-          sortKey: [Book, $id]
-          id: string
-          name: string
+          Book:
+            partitionKey: [$id]
+            sortKey: [Book, $id]
 
-    GSIs:
+    gsis:
       modelById:
         partitionKey: $model
         sortKey: $id
@@ -211,23 +240,30 @@ Tables:
 
 it("should generate GSI for Beyonces model field", () => {
   const result = generateCode(`
-Tables:
+tables:
   Library:
-    Partitions:
+    models:
+      Author:
+        id: string
+        name: string
+
+      Book:
+        id: string
+        name: string
+
+    partitions:
       Authors:
-        Author:
-          partitionKey: [Author, $id]
-          sortKey: [Author, $id]
-          id: string
-          name: string
+        partitionKeyPrefix: Author
+        models:
+          Author:
+            partitionKey: [$id]
+            sortKey: [Author, $id]
 
-        Book:
-          partitionKey: [Author, $id]
-          sortKey: [Book, $id]
-          id: string
-          name: string
+          Book:
+            partitionKey: [$id]
+            sortKey: [Book, $id]
 
-    GSIs:
+    gsis:
       modelById:
         partitionKey: $model
         sortKey: $id
@@ -243,23 +279,30 @@ Tables:
 
 it("should generate GSI with specified fields", () => {
   const result = generateCode(`
-Tables:
+tables:
   Library:
-    Partitions:
+    models:
+      Author:
+        id: string
+        name: string
+
+      Book:
+        id: string
+        name: string
+
+    partitions:
       Authors:
-        Author:
-          partitionKey: [Author, $id]
-          sortKey: [Author, $id]
-          id: string
-          name: string
+        partitionKeyPrefix: Author
+        models:
+          Author:
+            partitionKey: [$id]
+            sortKey: [Author, $id]
 
-        Book:
-          partitionKey: [Author, $id]
-          sortKey: [Book, $id]
-          id: string
-          name: string
+          Book:
+            partitionKey: [$id]
+            sortKey: [Book, $id]
 
-    GSIs:
+    gsis:
       byNameAndId:
         partitionKey: $name
         sortKey: $id
@@ -274,23 +317,29 @@ Tables:
 
 it("should generate GSI with pk and sk swapped", () => {
   const result = generateCode(`
-Tables:
+tables:
   Library:
-    Partitions:
+    models:
+      Author:
+        id: string
+        name: string
+
+      Book:
+        id: string
+        name: string
+
+    partitions:
       Authors:
-        Author:
-          partitionKey: [Author, $id]
-          sortKey: [Author, $id]
-          id: string
-          name: string
+        partitionKeyPrefix: Author
+        models:
+          Author:
+            partitionKey: [$id]
+            sortKey: [Author, $id]
 
-        Book:
-          partitionKey: [Author, $id]
-          sortKey: [Book, $id]
-          id: string
-          name: string
-
-    GSIs:
+          Book:
+            partitionKey: [$id]
+            sortKey: [Book, $id]
+    gsis:
       byNameAndId:
         partitionKey: $sk
         sortKey: $pk
@@ -305,15 +354,20 @@ Tables:
 
 it("should import external TypeScript types from a package", () => {
   const result = generateCode(`
-Tables:
+tables:
   Library:
-    Partitions:
+    models:
+      Author:
+        id: string
+        name: BestNameEvah from @cool.io/some/sweet/package
+
+    partitions:
       Authors:
-        Author:
-          partitionKey: [Author, $id]
-          sortKey: [Author, $id]
-          id: string
-          name: BestNameEvah from @cool.io/some/sweet/package
+        partitionKeyPrefix: Author
+        models:
+          Author:
+            partitionKey: [$id]
+            sortKey: [Author, $id]
 `)
 
   const lines = result.split("\n").map((_) => _.trim())
@@ -326,15 +380,20 @@ Tables:
 
 it("should generate a complex key model", () => {
   const result = generateCode(`
-Tables:
+tables:
   ComplexLibrary:
-    Partitions:
+    models:
+      ComplexAuthor:
+        id: string
+        name: string
+
+    partitions:
       ComplexAuthors:
-        ComplexAuthor:
-          partitionKey: [Author, $id]
-          sortKey: [Author, $id, $name]
-          id: string
-          name: string
+        partitionKeyPrefix: Author
+        models:
+          ComplexAuthor:
+            partitionKey: [$id]
+            sortKey: [Author, $id, $name]
 `)
 
   expect(result).toEqual(`import { Table } from "@ginger.io/beyonce"


### PR DESCRIPTION
This PR restructures the format of Beyonce's YAML configuration file. Now, we separate the definition of model fields (i.e. just the data) from their partition and sort key definitions (i.e. how we stuff them into Dynamo).

This is also closer to an end goal where we'd be able to define model fields as TypeScript interfaces and the partition/sort keys as external configuration. 