### PR TITLE
[Beyonce]: Don't fail if model field is set to undefined when JayZ is enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "./src"
   ],
   "dependencies": {
-    "@ginger.io/jay-z": "0.0.10",
+    "@ginger.io/jay-z": "0.0.12",
     "aws-sdk": "^2.760.0",
     "aws-xray-sdk": "^3.2.0",
     "fast-json-stable-stringify": "^2.1.0",

--- a/src/test/dynamo/Beyonce.test.ts
+++ b/src/test/dynamo/Beyonce.test.ts
@@ -1,6 +1,5 @@
-import { FixedDataKeyProvider, JayZ } from "@ginger.io/jay-z"
+import { JayZ } from "@ginger.io/jay-z"
 import { DynamoDB } from "aws-sdk"
-import crypto from "crypto"
 import { Beyonce } from "../../main/dynamo/Beyonce"
 import {
   aMusicianWithTwoSongs,
@@ -9,11 +8,10 @@ import {
   ModelType,
   MusicianModel,
   MusicianPartition,
-  Song,
   SongModel,
   table
 } from "./models"
-import { setup, createJayZ } from "./util"
+import { createJayZ, setup } from "./util"
 
 describe("Beyonce", () => {
   // Without encryption

--- a/src/test/dynamo/Beyonce.test.ts
+++ b/src/test/dynamo/Beyonce.test.ts
@@ -191,7 +191,7 @@ describe("Beyonce", () => {
     await testPutAndRetrieveItem(jayZ)
   })
 
-  it("should put and retrieve an item with an undefined field", async () => {
+  it("should put and retrieve an item with an undefined field with jayZ", async () => {
     const jayZ = await createJayZ()
     await testPutAndRetrieveItemWithUndefinedField(jayZ)
   })

--- a/src/test/dynamo/Beyonce.test.ts
+++ b/src/test/dynamo/Beyonce.test.ts
@@ -19,6 +19,10 @@ describe("Beyonce", () => {
     await testPutAndRetrieveItem()
   })
 
+  it("should put and retrieve an item with an undefined field", async () => {
+    await testPutAndRetrieveItemWithUndefinedField()
+  })
+
   it("should put and retrieve a model with a compound partition key", async () => {
     await testPutAndRetrieveCompoundPartitionKey()
   })
@@ -187,6 +191,11 @@ describe("Beyonce", () => {
     await testPutAndRetrieveItem(jayZ)
   })
 
+  it("should put and retrieve an item with an undefined field", async () => {
+    const jayZ = await createJayZ()
+    await testPutAndRetrieveItemWithUndefinedField(jayZ)
+  })
+
   it("should put and retrieve a model with a compound partition key with jayZ", async () => {
     const jayZ = await createJayZ()
     await testPutAndRetrieveCompoundPartitionKey(jayZ)
@@ -230,6 +239,22 @@ describe("Beyonce", () => {
 async function testPutAndRetrieveItem(jayZ?: JayZ) {
   const db = await setup(jayZ)
   const [musician, _, __] = aMusicianWithTwoSongs()
+  await db.put(musician)
+
+  const result = await db.get(MusicianModel.key({ id: musician.id }))
+  expect(result).toEqual(musician)
+}
+
+async function testPutAndRetrieveItemWithUndefinedField(jayZ?: JayZ) {
+  const db = await setup(jayZ)
+  const musician = MusicianModel.create({
+    id: "1",
+    name: "Bob Marley",
+    divaRating: undefined,
+    details: {
+      description: "rasta man"
+    }
+  })
   await db.put(musician)
 
   const result = await db.get(MusicianModel.key({ id: musician.id }))
@@ -359,6 +384,7 @@ async function testInvertedIndexGSI(jayZ?: JayZ) {
   const santana = MusicianModel.create({
     id: "1",
     name: "Santana",
+    divaRating: 10,
     details: {
       description: "famous guitarist"
     }
@@ -367,6 +393,7 @@ async function testInvertedIndexGSI(jayZ?: JayZ) {
   const slash = MusicianModel.create({
     id: "2",
     name: "Slash",
+    divaRating: 25,
     details: {
       description: "another famous guitarist"
     }

--- a/src/test/dynamo/models.ts
+++ b/src/test/dynamo/models.ts
@@ -3,18 +3,19 @@ import { Table } from "../../main/dynamo/Table"
 export const table = new Table({
   name: "TestTable",
   partitionKeyName: "pk",
-  sortKeyName: "sk",
+  sortKeyName: "sk"
 })
 
 export enum ModelType {
   Musician = "musician",
-  Song = "song",
+  Song = "song"
 }
 
 export interface Musician {
   model: ModelType.Musician
   id: string
   name: string
+  divaRating: number | undefined
   details: {
     description?: string
   }
@@ -56,23 +57,24 @@ export function aMusicianWithTwoSongs(): [Musician, Song, Song] {
   const musician = MusicianModel.create({
     id: "1",
     name: "Bob Marley",
+    divaRating: 0,
     details: {
-      description: "rasta man",
-    },
+      description: "rasta man"
+    }
   })
 
   const song1 = SongModel.create({
     musicianId: "1",
     id: "2",
     title: "Buffalo Soldier",
-    mp3: Buffer.from("fake-data", "utf8"),
+    mp3: Buffer.from("fake-data", "utf8")
   })
 
   const song2 = SongModel.create({
     musicianId: "1",
     id: "3",
     title: "No Woman, No Cry",
-    mp3: Buffer.from("fake-data", "utf8"),
+    mp3: Buffer.from("fake-data", "utf8")
   })
 
   return [musician, song1, song2]

--- a/yarn.lock
+++ b/yarn.lock
@@ -134,10 +134,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@ginger.io/jay-z@0.0.10":
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/@ginger.io/jay-z/-/jay-z-0.0.10.tgz#c7df84e5d08045637c8a7efe4afca6c42fbd2dea"
-  integrity sha512-KX4ZQZy2NyoF0ODYs6BZnWgXMh3Kg/WSvEHyymOBSrWoJqnZdqDNyaHxI9QmC8qaIGiz7s/ajSE5vZAAKMk7bA==
+"@ginger.io/jay-z@0.0.12":
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/@ginger.io/jay-z/-/jay-z-0.0.12.tgz#923e1a7fab568c398addc02725f18e1a0d17fe3d"
+  integrity sha512-lYzXOgpxiH9dtpbUxJUZodZQxBTiWRS3i8jIeLWspry9ZkOxv61oraF8QY6sg8Unr/lFfUSaN7UvH5QpyrQXXQ==
   dependencies:
     aws-sdk "^2.640.0"
     fast-json-stable-stringify "^2.1.0"


### PR DESCRIPTION
This PR prevents errors from occurring in Beyonce if you:

1. You have JayZ (encryption library) enabled
2. You attempt to save a model to Dynamo that has a k/v pair where the key is present but the value is `undefined`
3. You attempt to read that model back

This is a bug that was fixed in: https://github.com/ginger-io/jay-z/pull/10. So this PR just pulls in the latest JayZ library + adds unit tests to ensure it works within the context of Beyonce/Dynamo as expected. 