### PR TITLE
[Beyonce]: Better error handling for paged iterators

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,9 @@ const authorWithFilteredBooks = await beyonce
 
 #### Paginating Queries
 
-When you call `.exec()` Beyoncé will automatically page through all the results and return them to you. If you would like to step through pages manually (e.g to throttle reads) -- use the `.iterator()` method instead:
+When you call `.exec()` Beyoncé will automatically page through all the results and return them to you.
+
+If you would like to step through pages manually (e.g to throttle reads) -- use the `.iterator()` method instead:
 
 ```TypeScript
 const iterator = beyonce
@@ -241,10 +243,16 @@ const iterator = beyonce
   .iterator({ pageSize: 1 })
 
 // Step through each page 1 by 1
-for await (const { items } of iterator) {
+for await (const { items, errors } of iterator) {
    // ...
 }
 ```
+
+The `errors` field above contains any exceptions thrown while attempting to load the next iterator "page".
+So it's up to you, the caller to decide if you want to continue walking the iterator, or give up and exit.
+
+**Important**: When an error is encountered within the iterator, the _entire_ "page" is not processed,
+you'll get an errors array, but no items.
 
 ##### Cursors
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ginger.io/beyonce",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "description": "Type-safe DynamoDB query builder for TypeScript. Designed with single-table architecture in mind.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/main/dynamo/ScanBuilder.ts
+++ b/src/main/dynamo/ScanBuilder.ts
@@ -7,7 +7,7 @@ import {
   groupAllPages,
   IteratorOptions,
   pagedIterator,
-  PaginatedQueryResults,
+  PaginatedQueryResults
 } from "./pagedIterator"
 import { Table } from "./Table"
 import { GroupedModels, TaggedModel } from "./types"
@@ -55,15 +55,17 @@ export class ScanBuilder<T extends TaggedModel> extends QueryExpressionBuilder<
     )
 
     for await (const response of iterator) {
+      const errors = response.error ? [response.error] : undefined
       yield {
         items: groupModelsByType(response.items, this.modelTags),
-        cursor: response.lastEvaluatedKey,
+        errors,
+        cursor: response.lastEvaluatedKey
       }
     }
 
     return {
       items: groupModelsByType<T>([], this.modelTags),
-      cursor: undefined,
+      cursor: undefined
     }
   }
 
@@ -91,7 +93,7 @@ export class ScanBuilder<T extends TaggedModel> extends QueryExpressionBuilder<
       ExclusiveStartKey: options.cursor,
       Limit: options.pageSize,
       Segment: parallel?.segmentId,
-      TotalSegments: parallel?.totalSegments,
+      TotalSegments: parallel?.totalSegments
     }
 
     this.reset()

--- a/src/test/dynamo/query.test.ts
+++ b/src/test/dynamo/query.test.ts
@@ -163,7 +163,10 @@ async function testQueryWithCombinedAttributeFilters(jayZ?: JayZ) {
     .orAttributeNotExists("mp3")
     .exec()
 
-  expect(result).toEqual({ musician: [musician], song: [song1, song2] })
+  expect(result).toEqual({
+    musician: [musician],
+    song: [song1, song2]
+  })
 }
 
 async function testQueryWithLimit(jayZ?: JayZ) {
@@ -211,5 +214,8 @@ async function testPutAndRetrieveMultipleItems(jayZ?: JayZ) {
   const result = await db
     .query(MusicianPartition.key({ id: musician.id }))
     .exec()
-  expect(result).toEqual({ musician: [musician], song: [song1, song2] })
+  expect(result).toEqual({
+    musician: [musician],
+    song: [song1, song2]
+  })
 }

--- a/src/test/dynamo/scan.test.ts
+++ b/src/test/dynamo/scan.test.ts
@@ -110,7 +110,7 @@ describe("Beyonce.scan with JayZ", () => {
     // TODO: clean this up.
     // We get 24 items processed, not 25 here because the last "good"
     // item ends up in the same iterator "page" as the "bad item".
-    // i.e. if we a record in a page that we can't process, we give up on the whole page and move on
+    // i.e. if we get a record in a page that we can't process, we give up on the whole page and move on
     // Ideally, we'd process the rest of records in the page
     expect(songs.length).toEqual(24)
     expect(errors).toEqual([


### PR DESCRIPTION
Previously, if you attempted a `Query` or `Scan` operation using a paged iterator and you hit an error, the iterator would give up and terminate itself. Now, we yield control to the caller by handing them an `errors` array so they can decide wether or not they'd like to proceed with their operation, or give up. 

One place where this is useful is if you're performing a full table scan, and you don't want a bad record or two to stop your scan cold. 