### PR TITLE
[Beyonce]: Allow partial success when decrypting items within an iterator page

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,8 +251,8 @@ for await (const { items, errors } of iterator) {
 The `errors` field above contains any exceptions thrown while attempting to load the next iterator "page".
 So it's up to you, the caller to decide if you want to continue walking the iterator, or give up and exit.
 
-**Important**: When an error is encountered within the iterator, the _entire_ "page" is not processed,
-you'll get an errors array, but no items.
+**Important**: When an error is encountered within the iterator, you might get a partial result
+that contains one or more `items` and one or more `errors`. Thus, you should always check `errors.length`.
 
 ##### Cursors
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ginger.io/beyonce",
-  "version": "0.0.53",
+  "version": "0.0.55",
   "description": "Type-safe DynamoDB query builder for TypeScript. Designed with single-table architecture in mind.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,7 +12,7 @@
     "./src"
   ],
   "dependencies": {
-    "@ginger.io/jay-z": "0.0.12",
+    "@ginger.io/jay-z": "0.0.13",
     "aws-sdk": "^2.760.0",
     "aws-xray-sdk": "^3.2.0",
     "fast-json-stable-stringify": "^2.1.0",

--- a/src/main/CompositeError.ts
+++ b/src/main/CompositeError.ts
@@ -1,0 +1,11 @@
+/** An error that wraps multiple other errors.
+ *
+ *  TODO: Replace with AggregateError once Node 15 is our lowest supported version.
+ *  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError
+ */
+export class CompositeError extends Error {
+  constructor(message: string, public readonly errors: Error[]) {
+    super(message)
+    this.name = "CompositeError"
+  }
+}

--- a/src/main/dynamo/Beyonce.ts
+++ b/src/main/dynamo/Beyonce.ts
@@ -16,8 +16,7 @@ import { updateItemProxy } from "./updateItemProxy"
 import {
   decryptOrPassThroughItem,
   encryptOrPassThroughItem,
-  MaybeEncryptedItem,
-  toJSON
+  MaybeEncryptedItem
 } from "./util"
 
 export type Options = {
@@ -92,7 +91,7 @@ export class Beyonce {
 
     if (item !== undefined) {
       const maybeDecryptedItem = await decryptOrPassThroughItem(this.jayz, item)
-      return toJSON<T>(maybeDecryptedItem)
+      return maybeDecryptedItem as T
     }
   }
 
@@ -155,7 +154,7 @@ export class Beyonce {
           this.jayz,
           item
         )
-        return toJSON<ExtractKeyType<T>>(maybeDecryptedItem)
+        return maybeDecryptedItem as ExtractKeyType<T>
       })
 
       const jsonItems = await Promise.all(jsonItemPromises)
@@ -261,7 +260,7 @@ export class Beyonce {
       .promise()
 
     if (result.Attributes !== undefined) {
-      return toJSON<T>(result.Attributes)
+      return result.Attributes as T
     } else {
       throw new Error(
         `Item pk: ${key.partitionKey}, sk: ${key.sortKey} not found`

--- a/src/main/dynamo/QueryBuilder.ts
+++ b/src/main/dynamo/QueryBuilder.ts
@@ -8,7 +8,7 @@ import {
   groupAllPages,
   IteratorOptions,
   pagedIterator,
-  PaginatedQueryResults,
+  PaginatedQueryResults
 } from "./pagedIterator"
 import { Table } from "./Table"
 import { GroupedModels, TaggedModel } from "./types"
@@ -68,13 +68,15 @@ export class QueryBuilder<T extends TaggedModel> extends QueryExpressionBuilder<
     for await (const response of iterator) {
       yield {
         items: groupModelsByType(response.items, this.modelTags),
-        cursor: response.lastEvaluatedKey,
+        errors: response.errors,
+        cursor: response.lastEvaluatedKey
       }
     }
 
     return {
       items: groupModelsByType<T>([], this.modelTags),
-      cursor: undefined,
+      errors: [],
+      cursor: undefined
     }
   }
 
@@ -97,7 +99,7 @@ export class QueryBuilder<T extends TaggedModel> extends QueryExpressionBuilder<
         FilterExpression: filterExp,
         ExclusiveStartKey: options.cursor,
         ScanIndexForward: this.scanIndexForward,
-        Limit: options.pageSize,
+        Limit: options.pageSize
       }
     } else {
       const { table, consistentRead } = this.config
@@ -115,7 +117,7 @@ export class QueryBuilder<T extends TaggedModel> extends QueryExpressionBuilder<
         FilterExpression: filterExp,
         ExclusiveStartKey: options.cursor,
         ScanIndexForward: this.scanIndexForward,
-        Limit: options.pageSize,
+        Limit: options.pageSize
       }
     }
 

--- a/src/main/dynamo/ScanBuilder.ts
+++ b/src/main/dynamo/ScanBuilder.ts
@@ -55,10 +55,9 @@ export class ScanBuilder<T extends TaggedModel> extends QueryExpressionBuilder<
     )
 
     for await (const response of iterator) {
-      const errors = response.error ? [response.error] : undefined
       yield {
         items: groupModelsByType(response.items, this.modelTags),
-        errors,
+        errors: response.errors,
         cursor: response.lastEvaluatedKey
       }
     }

--- a/src/main/dynamo/ScanBuilder.ts
+++ b/src/main/dynamo/ScanBuilder.ts
@@ -64,6 +64,7 @@ export class ScanBuilder<T extends TaggedModel> extends QueryExpressionBuilder<
 
     return {
       items: groupModelsByType<T>([], this.modelTags),
+      errors: [],
       cursor: undefined
     }
   }

--- a/src/main/dynamo/pagedIterator.ts
+++ b/src/main/dynamo/pagedIterator.ts
@@ -1,9 +1,10 @@
 import { JayZ } from "@ginger.io/jay-z"
 import { DynamoDB } from "aws-sdk"
 import { DocumentClient } from "aws-sdk/clients/dynamodb"
+import { CompositeError } from "../CompositeError"
 import { groupModelsByType } from "./groupModelsByType"
 import { GroupedModels, TaggedModel } from "./types"
-import { decryptOrPassThroughItems, toJSON } from "./util"
+import { decryptOrPassThroughItem, toJSON } from "./util"
 
 export type Cursor = Record<string, any>
 
@@ -19,7 +20,7 @@ export type RawDynamoDBPage = {
 
 export type PageResults<T extends TaggedModel> = {
   items: T[]
-  error?: Error
+  errors: Error[]
   lastEvaluatedKey?: DynamoDB.DocumentClient.Key
 }
 
@@ -39,11 +40,15 @@ export async function groupAllPages<T extends TaggedModel>(
   modelTags: string[]
 ): Promise<GroupedModels<T>> {
   const results: T[] = []
-  for await (const { items, error } of iterator) {
-    results.push(...items)
-    if (error) {
-      throw error
+  for await (const { items, errors } of iterator) {
+    if (errors.length > 0) {
+      throw new CompositeError(
+        "Error(s) encountered trying to process interator page",
+        errors
+      )
     }
+
+    results.push(...items)
   }
 
   return groupModelsByType(results, modelTags)
@@ -59,6 +64,8 @@ export async function* pagedIterator<T, U extends TaggedModel>(
   let cursor: Cursor | undefined
 
   while (pendingOperation !== undefined) {
+    const items: U[] = []
+    const errors: Error[] = []
     try {
       const response: DynamoDB.DocumentClient.QueryOutput = await executeOperation(
         pendingOperation
@@ -71,17 +78,24 @@ export async function* pagedIterator<T, U extends TaggedModel>(
         pendingOperation = undefined
       }
 
-      const maybeDecryptedItems = await decryptOrPassThroughItems(
-        jayz,
-        response.Items || []
-      )
+      const itemsToDecrypt = response.Items ?? []
 
-      const items = maybeDecryptedItems.map((item) => toJSON<U>(item))
-      yield { items, lastEvaluatedKey: cursor }
+      const itemPromises = itemsToDecrypt.map(async (item) => {
+        try {
+          const maybeDecryptedItem = await decryptOrPassThroughItem(jayz, item)
+          items.push(toJSON<U>(maybeDecryptedItem))
+        } catch (error) {
+          errors.push(error)
+        }
+      })
+
+      await Promise.all(itemPromises)
+      yield { items, lastEvaluatedKey: cursor, errors }
     } catch (error) {
-      yield { items: [], lastEvaluatedKey: cursor, error }
+      errors.push(error)
+      yield { items: [], lastEvaluatedKey: cursor, errors }
     }
   }
 
-  return { items: [], lastEvaluatedKey: undefined }
+  return { items: [], errors: [], lastEvaluatedKey: undefined }
 }

--- a/src/main/dynamo/pagedIterator.ts
+++ b/src/main/dynamo/pagedIterator.ts
@@ -31,7 +31,7 @@ export type PaginatedQueryResults<T extends TaggedModel> = AsyncGenerator<
 
 export type QueryResults<T extends TaggedModel> = {
   items: GroupedModels<T>
-  errors?: Error[]
+  errors: Error[]
   cursor?: Cursor
 }
 

--- a/src/main/dynamo/pagedIterator.ts
+++ b/src/main/dynamo/pagedIterator.ts
@@ -4,7 +4,7 @@ import { DocumentClient } from "aws-sdk/clients/dynamodb"
 import { CompositeError } from "../CompositeError"
 import { groupModelsByType } from "./groupModelsByType"
 import { GroupedModels, TaggedModel } from "./types"
-import { decryptOrPassThroughItem, toJSON } from "./util"
+import { decryptOrPassThroughItem } from "./util"
 
 export type Cursor = Record<string, any>
 
@@ -83,7 +83,7 @@ export async function* pagedIterator<T, U extends TaggedModel>(
       const itemPromises = itemsToDecrypt.map(async (item) => {
         try {
           const maybeDecryptedItem = await decryptOrPassThroughItem(jayz, item)
-          items.push(toJSON<U>(maybeDecryptedItem))
+          items.push(maybeDecryptedItem as U)
         } catch (error) {
           errors.push(error)
         }

--- a/src/main/dynamo/util.ts
+++ b/src/main/dynamo/util.ts
@@ -4,10 +4,6 @@ export type MaybeEncryptedItem<T> =
   | EncryptedJayZItem<T & Record<string, string>, string>
   | (T & Record<string, string>)
 
-export function toJSON<T>(item: { [key: string]: any }): T {
-  return item as T
-}
-
 export async function encryptOrPassThroughItem<T extends Record<string, any>>(
   jayz: JayZ | undefined,
   item: T,

--- a/src/main/dynamo/util.ts
+++ b/src/main/dynamo/util.ts
@@ -1,6 +1,6 @@
 import { EncryptedJayZItem, JayZ } from "@ginger.io/jay-z"
 
-export type MaybeEncryptedItems<T> =
+export type MaybeEncryptedItem<T> =
   | EncryptedJayZItem<T & Record<string, string>, string>
   | (T & Record<string, string>)
 
@@ -8,36 +8,34 @@ export function toJSON<T>(item: { [key: string]: any }): T {
   return item as T
 }
 
-export async function encryptOrPassThroughItems<T extends Record<string, any>>(
+export async function encryptOrPassThroughItem<T extends Record<string, any>>(
   jayz: JayZ | undefined,
-  items: T[],
+  item: T,
   encryptionBlacklist: Set<string>
-): Promise<MaybeEncryptedItems<T>[]> {
+): Promise<MaybeEncryptedItem<T>> {
   if (jayz !== undefined) {
-    const itemsToEncrypt = items.map((item) => {
-      const fieldsToEncrypt = Object.keys(item).filter(
-        (_) => !encryptionBlacklist.has(_)
-      )
+    const fieldsToEncrypt = Object.keys(item).filter(
+      (_) => !encryptionBlacklist.has(_)
+    )
 
-      return {
-        item,
-        fieldsToEncrypt
-      }
+    await jayz.ready
+    return jayz.encryptItem({
+      item,
+      fieldsToEncrypt
     })
-
-    return jayz.encryptItems(itemsToEncrypt)
   } else {
-    return items
+    return item
   }
 }
 
-export async function decryptOrPassThroughItems(
+export async function decryptOrPassThroughItem(
   jayz: JayZ | undefined,
-  items: Record<string, any>[]
-): Promise<{ [key: string]: any }[]> {
+  item: Record<string, any>
+): Promise<{ [key: string]: any }> {
   if (jayz !== undefined) {
-    return jayz.decryptItems(items as EncryptedJayZItem<any, any>[])
+    await jayz.ready
+    return jayz.decryptItem(item as EncryptedJayZItem<any, any>)
   } else {
-    return items
+    return item
   }
 }

--- a/src/test/dynamo/scan.test.ts
+++ b/src/test/dynamo/scan.test.ts
@@ -107,12 +107,7 @@ describe("Beyonce.scan with JayZ", () => {
       }
     }
 
-    // TODO: clean this up.
-    // We get 24 items processed, not 25 here because the last "good"
-    // item ends up in the same iterator "page" as the "bad item".
-    // i.e. if we get a record in a page that we can't process, we give up on the whole page and move on
-    // Ideally, we'd process the rest of records in the page
-    expect(songs.length).toEqual(24)
+    expect(songs.length).toEqual(25)
     expect(errors).toEqual([
       new Error("wrong secret key for the given ciphertext")
     ])

--- a/src/test/dynamo/util.ts
+++ b/src/test/dynamo/util.ts
@@ -43,7 +43,9 @@ export function createBeyonce(db: DynamoDB, jayz?: JayZ): Beyonce {
 
 export async function createJayZ(): Promise<JayZ> {
   const keyProvider = await FixedDataKeyProvider.forLibsodium()
-  return new JayZ({ keyProvider })
+  const jayz = new JayZ({ keyProvider })
+  await jayz.ready
+  return jayz
 }
 
 // DynamoDB has a 400kb Item limit w/ a 1MB response size limit

--- a/yarn.lock
+++ b/yarn.lock
@@ -134,10 +134,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@ginger.io/jay-z@0.0.12":
-  version "0.0.12"
-  resolved "https://registry.yarnpkg.com/@ginger.io/jay-z/-/jay-z-0.0.12.tgz#923e1a7fab568c398addc02725f18e1a0d17fe3d"
-  integrity sha512-lYzXOgpxiH9dtpbUxJUZodZQxBTiWRS3i8jIeLWspry9ZkOxv61oraF8QY6sg8Unr/lFfUSaN7UvH5QpyrQXXQ==
+"@ginger.io/jay-z@0.0.13":
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/@ginger.io/jay-z/-/jay-z-0.0.13.tgz#9adfb87e40399a23f4d0c11c4cad8f681fe2a144"
+  integrity sha512-2KSzOfK/enrrXM0Qzow5UqapCe4aySf4/T/7ORNRGuZB0UYwAM6RTwUri7fRHbpFUbrPGWEE9IwUy+8kKb2INg==
   dependencies:
     aws-sdk "^2.640.0"
     fast-json-stable-stringify "^2.1.0"


### PR DESCRIPTION
https://github.com/ginger-io/beyonce/pull/50 added support to allow callers who invoked `Query` and `Scan` operations to continue processing if a loading particular iterator page generated an error. 

But if encryption was enabled via our JayZ library, one bad record would result in giving up on the entire page of records. This PR fixes that.

Now, if we encounter one or more bad records within an iterator page, we'll process as many as we can + return errors for the rest.