### PR TITLE
[Beyonce]: Fix a bug where pagedIterators would "forget" their filters after processing the 1st page

### DIFF
--- a/src/main/dynamo/Beyonce.ts
+++ b/src/main/dynamo/Beyonce.ts
@@ -9,7 +9,7 @@ import {
   PartitionKeyAndSortKeyPrefix
 } from "./keys"
 import { QueryBuilder } from "./QueryBuilder"
-import { ParallelScanConfig, ScanBuilder } from "./ScanBuilder"
+import { ScanBuilder, ParallelScanConfig } from "./ScanBuilder"
 import { Table } from "./Table"
 import { ExtractKeyType, GroupedModels, TaggedModel } from "./types"
 import { updateItemProxy } from "./updateItemProxy"

--- a/src/main/dynamo/expressions/QueryExpressionBuilder.ts
+++ b/src/main/dynamo/expressions/QueryExpressionBuilder.ts
@@ -71,7 +71,7 @@ export class QueryExpressionBuilder<T extends TaggedModel> {
     return {
       expression,
       attributeNames,
-      attributeValues,
+      attributeValues
     }
   }
 
@@ -84,12 +84,6 @@ export class QueryExpressionBuilder<T extends TaggedModel> {
 
   protected addStatement(statement: string): void {
     this.statements.push(statement)
-  }
-
-  protected reset(): void {
-    this.attributeNames = new Attributes()
-    this.attributeValues = new Variables()
-    this.statements = []
   }
 
   private addCondition(params: {

--- a/src/test/dynamo/Beyonce.test.ts
+++ b/src/test/dynamo/Beyonce.test.ts
@@ -123,7 +123,7 @@ describe("Beyonce", () => {
       .query(MusicianModel.partitionKey({ id: "musician-1" }), {
         consistentRead: true
       })
-      .buildQuery({})
+      .createQueryInput({})
 
     expect(query).toMatchObject({
       ConsistentRead: true


### PR DESCRIPTION
This PR fixes a bug where if you: 

1. Called `scan` or `query` 
2. Added filtering via `where(...)`
3. Called the `iterator()` method (instead of `exec`)

Your first page of results would have the filter applied, but subsequent ones would not. 