### PR TITLE
[Beyonce] Make Cursor values opaque to the caller

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ginger.io/beyonce",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "description": "Type-safe DynamoDB query builder for TypeScript. Designed with single-table architecture in mind.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/main/dynamo/iterators/types.ts
+++ b/src/main/dynamo/iterators/types.ts
@@ -1,0 +1,27 @@
+import { DocumentClient } from "aws-sdk/clients/dynamodb"
+import { GroupedModels, TaggedModel } from "../types"
+
+export type Cursor = string
+
+/** Iterator related options exposed to the caller facing API */
+export interface IteratorOptions {
+  cursor?: Cursor
+  pageSize?: number
+}
+
+/** Iterator options intended for internal use (within this library) */
+export interface InternalIteratorOptions {
+  lastEvaluatedKey: DocumentClient.Key | undefined
+  pageSize?: number
+}
+
+export interface IteratorResults<T extends TaggedModel> {
+  items: GroupedModels<T>
+  errors: Error[]
+  cursor?: Cursor
+}
+
+export type PaginatedIteratorResults<T extends TaggedModel> = AsyncGenerator<
+  IteratorResults<T>,
+  IteratorResults<T>
+>

--- a/src/main/dynamo/iterators/util.ts
+++ b/src/main/dynamo/iterators/util.ts
@@ -1,0 +1,33 @@
+import { Cursor } from "aws-sdk/clients/cloudsearchdomain"
+import { DocumentClient } from "aws-sdk/clients/dynamodb"
+import { base64_variants, from_base64, to_base64 } from "libsodium-wrappers"
+import { TextDecoder } from "util"
+import { InternalIteratorOptions, IteratorOptions } from "./types"
+
+export function toInternalIteratorOptions(
+  options: IteratorOptions
+): InternalIteratorOptions {
+  return {
+    lastEvaluatedKey: maybeDeserializeCursor(options.cursor),
+    pageSize: options.pageSize
+  }
+}
+
+export function maybeSerializeCursor(
+  key?: DocumentClient.Key
+): string | undefined {
+  if (key) {
+    return to_base64(JSON.stringify(key), base64_variants.ORIGINAL_NO_PADDING)
+  }
+}
+
+export function maybeDeserializeCursor(
+  cursor?: Cursor
+): DocumentClient.Key | undefined {
+  if (cursor) {
+    const json = new TextDecoder().decode(
+      from_base64(cursor, base64_variants.ORIGINAL_NO_PADDING)
+    )
+    return JSON.parse(json)
+  }
+}

--- a/src/test/dynamo/iterators/util.test.ts
+++ b/src/test/dynamo/iterators/util.test.ts
@@ -1,0 +1,29 @@
+import { ready } from "libsodium-wrappers"
+import {
+  maybeDeserializeCursor,
+  maybeSerializeCursor
+} from "../../../main/dynamo/iterators/util"
+
+describe("iterator utils", () => {
+  beforeAll(async () => await ready)
+
+  it("should serialize a lastEvaluatedKey to a cursor", () => {
+    const cursor = maybeSerializeCursor({ pk: "Bob", sk: "Marley" })
+    expect(cursor).toEqual("eyJwayI6IkJvYiIsInNrIjoiTWFybGV5In0")
+  })
+
+  it("should not serialize an undefined lastEvaluatedKey", () => {
+    expect(maybeSerializeCursor()).toEqual(undefined)
+  })
+
+  it("should deserialize a cursor into a lastEvaluatedKey", () => {
+    const lastEvaluatedKey = maybeDeserializeCursor(
+      "eyJwayI6IkJvYiIsInNrIjoiTWFybGV5In0"
+    )
+    expect(lastEvaluatedKey).toEqual({ pk: "Bob", sk: "Marley" })
+  })
+
+  it("shoud not deserialize an undefined cursor", () => {
+    expect(maybeDeserializeCursor()).toEqual(undefined)
+  })
+})


### PR DESCRIPTION
This PR makes `Cursor` values returned by scan/query iterators opaque to the caller by base64 encoding them. 

This is nice from an API pov as it does not leak implementation details about what the cursor is (which is the DynamoDB last evaluated key). And, it also makes cursor values more compact for easier copy/pasting when you want to resume a query/scan from a particular iterator page. 