### PR TITLE
[Beyonce]: Add executeTransaction method / deprecate batchPutWithTransaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ const batchResults = await beyonce.batchGet({
 ### BatchPutWithTransaction
 
 ```TypeScript
-// Batch put several items in a transaction
+// Batch put or delete several items in a transaction
 const author1 = AuthorModel.create({
   id: "1",
   name: "Jane Austen"
@@ -370,7 +370,7 @@ const author2 = AuthorModel.create({
   name: "Charles Dickens"
 })
 
-await beyonce.batchPutWithTransaction({ items: [author1, author2] })
+await beyonce.executeTransaction({ putItems: [author1], deleteItems: [Author.key({ id: author2.id })] })
 ```
 
 ## Consistent Reads

--- a/src/main/dynamo/Beyonce.ts
+++ b/src/main/dynamo/Beyonce.ts
@@ -19,21 +19,21 @@ import {
   MaybeEncryptedItem
 } from "./util"
 
-export type Options = {
+export interface Options {
   jayz?: JayZ
   xRayTracingEnabled?: boolean
   consistentReads?: boolean
 }
 
-export type GetOptions = {
+export interface GetOptions {
   consistentRead?: boolean
 }
 
-export type QueryOptions = {
+export interface QueryOptions {
   consistentRead?: boolean
 }
 
-export type ScanOptions = {
+export interface ScanOptions {
   consistentRead?: boolean
   parallel?: ParallelScanConfig
 }

--- a/src/main/dynamo/QueryBuilder.ts
+++ b/src/main/dynamo/QueryBuilder.ts
@@ -18,7 +18,7 @@ import { PartitionKey, PartitionKeyAndSortKeyPrefix } from "./keys"
 import { Table } from "./Table"
 import { GroupedModels, TaggedModel } from "./types"
 
-type TableQueryConfig<T extends TaggedModel> = {
+interface TableQueryConfig<T extends TaggedModel> {
   db: DynamoDB.DocumentClient
   table: Table
   key: PartitionKey<T> | PartitionKeyAndSortKeyPrefix<T>
@@ -26,7 +26,7 @@ type TableQueryConfig<T extends TaggedModel> = {
   consistentRead?: boolean
 }
 
-type GSIQueryConfig<T extends TaggedModel> = {
+interface GSIQueryConfig<T extends TaggedModel> {
   db: DynamoDB.DocumentClient
   table: Table
   gsiName: string

--- a/src/main/dynamo/ScanBuilder.ts
+++ b/src/main/dynamo/ScanBuilder.ts
@@ -17,7 +17,7 @@ import {
 import { Table } from "./Table"
 import { GroupedModels, TaggedModel } from "./types"
 
-type ScanConfig<T extends TaggedModel> = {
+interface ScanConfig<T extends TaggedModel> {
   db: DynamoDB.DocumentClient
   table: Table
   jayz?: JayZ
@@ -25,7 +25,7 @@ type ScanConfig<T extends TaggedModel> = {
   parallel?: ParallelScanConfig
 }
 
-export type ParallelScanConfig = {
+export interface ParallelScanConfig {
   segmentId: number // 0-indexed -- i.e. first segment id is 0, not 1
   totalSegments: number
 }

--- a/src/test/dynamo/Beyonce.test.ts
+++ b/src/test/dynamo/Beyonce.test.ts
@@ -211,7 +211,8 @@ describe("Beyonce", () => {
   })
 
   it("should put and delete an item using pk + sk with jayZ", async () => {
-    await testPutAndDeleteItem()
+    const jayZ = await createJayZ()
+    await testPutAndDeleteItem(jayZ)
   })
 
   it("should put and delete in the same transaction with jayZ", async () => {

--- a/src/test/dynamo/Beyonce.test.ts
+++ b/src/test/dynamo/Beyonce.test.ts
@@ -117,6 +117,10 @@ describe("Beyonce", () => {
     await testPutAndDeleteItem()
   })
 
+  it("should put and delete in the same transaction", async () => {
+    await testPutAndDeleteItemInTransaction()
+  })
+
   it("should set consistent read on queries", async () => {
     const db = await setup()
     const query = await (db as any)
@@ -210,6 +214,11 @@ describe("Beyonce", () => {
     await testPutAndDeleteItem()
   })
 
+  it("should put and delete in the same transaction with jayZ", async () => {
+    const jayZ = await createJayZ()
+    await testPutAndDeleteItemInTransaction(jayZ)
+  })
+
   it("should batchGet items with jayZ", async () => {
     const jayZ = await createJayZ()
     await testBatchGet(jayZ)
@@ -271,6 +280,25 @@ async function testPutAndDeleteItem(jayZ?: JayZ) {
   expect(await db.get(key)).toEqual(musician)
   await db.delete(key)
   expect(await db.get(key)).toEqual(undefined)
+}
+
+async function testPutAndDeleteItemInTransaction(jayZ?: JayZ) {
+  const db = await setup(jayZ)
+  const [musician, song1, song2] = aMusicianWithTwoSongs()
+  await db.executeTransaction({ putItems: [musician, song1] })
+
+  await db.executeTransaction({
+    putItems: [song2],
+    deleteItems: [SongModel.key({ musicianId: song1.musicianId, id: song1.id })]
+  })
+
+  expect(
+    await db.get(SongModel.key({ musicianId: song2.musicianId, id: song2.id }))
+  ).toEqual(song2)
+
+  expect(
+    await db.get(SongModel.key({ musicianId: song1.musicianId, id: song1.id }))
+  ).toEqual(undefined)
 }
 
 async function testPutAndRetrieveCompoundPartitionKey(jayZ?: JayZ) {
@@ -413,8 +441,8 @@ async function testInvertedIndexGSI(jayZ?: JayZ) {
     mp3: Buffer.from("fake-data", "utf8")
   })
 
-  await db.batchPutWithTransaction({
-    items: [santana, slash, santanasSong, slashesSong]
+  await db.executeTransaction({
+    putItems: [santana, slash, santanasSong, slashesSong]
   })
 
   // Now when we query our inverted index, pk and sk are reversed,
@@ -432,7 +460,7 @@ async function testInvertedIndexGSI(jayZ?: JayZ) {
 async function testBatchWriteWithTransaction(jayZ?: JayZ) {
   const db = await setup(jayZ)
   const [musician, song1, song2] = aMusicianWithTwoSongs()
-  await db.batchPutWithTransaction({ items: [musician, song1, song2] })
+  await db.executeTransaction({ putItems: [musician, song1, song2] })
 
   const results = await db
     .query(MusicianPartition.key({ id: musician.id }))

--- a/src/test/dynamo/query.test.ts
+++ b/src/test/dynamo/query.test.ts
@@ -247,7 +247,7 @@ async function testQueryWithReverseAndLimit(jayZ?: JayZ) {
 async function testPutAndRetrieveMultipleItems(jayZ?: JayZ) {
   const db = await setup(jayZ)
   const [musician, song1, song2] = aMusicianWithTwoSongs()
-  await db.batchPutWithTransaction({ items: [musician, song1, song2] })
+  await db.executeTransaction({ putItems: [musician, song1, song2] })
 
   const result = await db
     .query(MusicianPartition.key({ id: musician.id }))

--- a/src/test/dynamo/util.ts
+++ b/src/test/dynamo/util.ts
@@ -64,10 +64,10 @@ export async function create25Songs(db: Beyonce): Promise<Song[]> {
   // Batch these to avoid DynamoDB local throwing errors about exceeding
   // the max payload size
   await Promise.all([
-    db.batchPutWithTransaction({ items: songs.slice(0, 5) }),
-    db.batchPutWithTransaction({ items: songs.slice(5, 10) }),
-    db.batchPutWithTransaction({ items: songs.slice(10, 15) }),
-    db.batchPutWithTransaction({ items: songs.slice(15) })
+    db.executeTransaction({ putItems: songs.slice(0, 5) }),
+    db.executeTransaction({ putItems: songs.slice(5, 10) }),
+    db.executeTransaction({ putItems: songs.slice(10, 15) }),
+    db.executeTransaction({ putItems: songs.slice(15) })
   ])
   return songs
 }


### PR DESCRIPTION
**What's in this PR?**

This PR adds a new `executeTransaction` method that allows callers to put and delete a set of records within the same transaction. We had a narrower method, `batchPutWithTransaction` which is now redundant and is thus marked as deprecated and will soon be removed. 

DynamoDB supports a wider range of transaction operations (e.g. conditions on the transaction and updating records), so we'll want to extend `executeTransaction` to handle these use cases as well.  But that is left to future PRs.

I snuck in a few small changes as separate commits -- fixing a test, and swapping several `type` definitions to `interfaces` (which allows for using the `extends` keyword). 

**How to review?**
Commit-by-commit