### PR TITLE
fix: [Beyonce] make returned cursor undefined when we hit final iterator page

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "prettier.semi": false,
     "prettier.trailingComma": "none",
     "editor.formatOnSave": true,
+    "jest.autoEnable": false,
     "files.exclude": {
         "**/.git": true,
         "**/.svn": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ginger.io/beyonce",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "description": "Type-safe DynamoDB query builder for TypeScript. Designed with single-table architecture in mind.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/main/dynamo/iterators/pagedIterator.ts
+++ b/src/main/dynamo/iterators/pagedIterator.ts
@@ -44,7 +44,7 @@ export async function* pagedIterator<T, U extends TaggedModel>(
   jayz?: JayZ
 ): AsyncGenerator<PageResults<U>, PageResults<U>> {
   let pendingOperation: T | undefined = buildOperation(options)
-  let { lastEvaluatedKey } = options
+  let lastEvaluatedKey = options.lastEvaluatedKey
 
   while (pendingOperation !== undefined) {
     const items: U[] = []
@@ -58,6 +58,7 @@ export async function* pagedIterator<T, U extends TaggedModel>(
         lastEvaluatedKey = response.LastEvaluatedKey
         pendingOperation = buildOperation({ ...options, lastEvaluatedKey })
       } else {
+        lastEvaluatedKey = undefined
         pendingOperation = undefined
       }
 


### PR DESCRIPTION
**What's in this PR?**
This PR fixes a bug with our paginated `query`/`scan` operators where the final iterator results page wasn't returning `undefined` for the `cursor` (which is a signal to the user that we're "all done"). Instead, we were returning a copy of the n-1 cursor. 