### PR TITLE
feat: Add batchWrite method

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,10 +356,13 @@ const batchResults = await beyonce.batchGet({
 // { author: Author[], book: Book[] }
 ```
 
-### BatchPutWithTransaction
+### BatchWrite
+
+You can batch put/delete records using `batchWrite`. If any operations can't be processed,
+you'll get a populated `unprocessedPuts` array and/or an `unprocessedDeletes` array back.
 
 ```TypeScript
-// Batch put or delete several items in a transaction
+// Batch put or delete several items at once
 const author1 = AuthorModel.create({
   id: "1",
   name: "Jane Austen"
@@ -370,7 +373,19 @@ const author2 = AuthorModel.create({
   name: "Charles Dickens"
 })
 
-await beyonce.executeTransaction({ putItems: [author1], deleteItems: [Author.key({ id: author2.id })] })
+const {
+  unprocessedPuts,
+  unprocessedDeletes
+} = await beyonce.batchWrite({ putItems: [author1], deleteItems: [Author.key({ id: author2.id })] })
+```
+
+#### BatchWriteWithTransaction
+
+If you'd like to batch pute/delete records in an atomic transaction, you can use `batchWriteWithTransaction`.
+And all operations will either succeed, or fail.
+
+```TypeScript
+await beyonce.batchWriteWithTransaction({ putItems: [author1], deleteItems: [Author.key({ id: author2.id })] })
 ```
 
 ## Consistent Reads

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ginger.io/beyonce",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "description": "Type-safe DynamoDB query builder for TypeScript. Designed with single-table architecture in mind.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/main/dynamo/Beyonce.ts
+++ b/src/main/dynamo/Beyonce.ts
@@ -268,17 +268,6 @@ export class Beyonce {
     }
   }
 
-  /** Write multiple items into Dynamo using a transaction.
-   *
-   *  @deprecated -- use batchWriteWithTransaction
-   */
-  async batchPutWithTransaction<T extends TaggedModel>(params: {
-    items: T[]
-  }): Promise<void> {
-    const { items } = params
-    await this.batchWriteWithTransaction({ putItems: items })
-  }
-
   async batchWrite<T extends TaggedModel>(params: {
     putItems?: T[]
     deleteItems?: PartitionAndSortKey<T>[]

--- a/src/main/dynamo/Beyonce.ts
+++ b/src/main/dynamo/Beyonce.ts
@@ -270,13 +270,13 @@ export class Beyonce {
 
   /** Write multiple items into Dynamo using a transaction.
    *
-   *  @deprecated -- use executeTransaction
+   *  @deprecated -- use batchWriteWithTransaction
    */
   async batchPutWithTransaction<T extends TaggedModel>(params: {
     items: T[]
   }): Promise<void> {
     const { items } = params
-    await this.executeTransaction({ putItems: items })
+    await this.batchWriteWithTransaction({ putItems: items })
   }
 
   async batchWrite<T extends TaggedModel>(params: {
@@ -332,7 +332,7 @@ export class Beyonce {
   }
 
   /** Perform N Dynamo operations in an atomic transaction */
-  async executeTransaction<T extends TaggedModel>(params: {
+  async batchWriteWithTransaction<T extends TaggedModel>(params: {
     putItems?: T[]
     deleteItems?: PartitionAndSortKey<T>[]
   }): Promise<void> {

--- a/src/test/dynamo/Beyonce.test.ts
+++ b/src/test/dynamo/Beyonce.test.ts
@@ -274,19 +274,19 @@ async function testPutAndRetrieveItem(jayZ?: JayZ) {
 }
 
 async function testPutAndRetrieveForItemWithEmptyFields(jayZ?: JayZ) {
-  const db = await setup(jayZ);
-  const [musician, song1, song2] = aMusicianWithTwoSongs();
-  song1.genre = undefined;
-  song2.genre = null;
-  await db.batchPut({ items: [musician, song1, song2] });
+  const db = await setup(jayZ)
+  const [musician, song1, song2] = aMusicianWithTwoSongs()
+  song1.genre = undefined
+  song2.genre = null
+  await db.batchWrite({ putItems: [musician, song1, song2] })
 
-  const result = await db.get(MusicianModel.key({ id: musician.id }));
+  const result = await db.get(MusicianModel.key({ id: musician.id }))
   expect(
     await db.get(SongModel.key({ musicianId: musician.id, id: song1.id }))
-  ).toEqual(song1);
+  ).toEqual(song1)
   expect(
     await db.get(SongModel.key({ musicianId: musician.id, id: song2.id }))
-  ).toEqual(song2);
+  ).toEqual(song2)
 }
 
 async function testPutAndRetrieveItemWithUndefinedField(jayZ?: JayZ) {
@@ -511,8 +511,8 @@ async function testBatchWriteWithTransaction(jayZ?: JayZ) {
 async function testBatchWrite(jayZ?: JayZ) {
   const db = await setup(jayZ)
   const [musician, song1, song2] = aMusicianWithTwoSongs()
-  await db.batchPut({
-    items: [musician, song1, song2]
+  await db.batchWrite({
+    putItems: [musician, song1, song2]
   })
 
   const results = await db

--- a/src/test/dynamo/Beyonce.test.ts
+++ b/src/test/dynamo/Beyonce.test.ts
@@ -244,7 +244,7 @@ describe("Beyonce", () => {
     await testInvertedIndexGSI(jayZ)
   })
 
-  it("should write multiple items at once in a transact with jayZ", async () => {
+  it("should write multiple items at once in a transaction with jayZ", async () => {
     const jayZ = await createJayZ()
     await testBatchWriteWithTransaction(jayZ)
   })

--- a/src/test/dynamo/Beyonce.test.ts
+++ b/src/test/dynamo/Beyonce.test.ts
@@ -320,9 +320,9 @@ async function testPutAndDeleteItem(jayZ?: JayZ) {
 async function testPutAndDeleteItemInTransaction(jayZ?: JayZ) {
   const db = await setup(jayZ)
   const [musician, song1, song2] = aMusicianWithTwoSongs()
-  await db.executeTransaction({ putItems: [musician, song1] })
+  await db.batchWriteWithTransaction({ putItems: [musician, song1] })
 
-  await db.executeTransaction({
+  await db.batchWriteWithTransaction({
     putItems: [song2],
     deleteItems: [SongModel.key({ musicianId: song1.musicianId, id: song1.id })]
   })
@@ -476,7 +476,7 @@ async function testInvertedIndexGSI(jayZ?: JayZ) {
     mp3: Buffer.from("fake-data", "utf8")
   })
 
-  await db.executeTransaction({
+  await db.batchWriteWithTransaction({
     putItems: [santana, slash, santanasSong, slashesSong]
   })
 
@@ -495,7 +495,7 @@ async function testInvertedIndexGSI(jayZ?: JayZ) {
 async function testBatchWriteWithTransaction(jayZ?: JayZ) {
   const db = await setup(jayZ)
   const [musician, song1, song2] = aMusicianWithTwoSongs()
-  await db.executeTransaction({ putItems: [musician, song1, song2] })
+  await db.batchWriteWithTransaction({ putItems: [musician, song1, song2] })
 
   const results = await db
     .query(MusicianPartition.key({ id: musician.id }))
@@ -511,8 +511,10 @@ async function testBatchWriteWithTransaction(jayZ?: JayZ) {
 async function testBatchWrite(jayZ?: JayZ) {
   const db = await setup(jayZ)
   const [musician, song1, song2] = aMusicianWithTwoSongs()
+  await db.put(song2)
   await db.batchWrite({
-    putItems: [musician, song1, song2]
+    putItems: [musician, song1],
+    deleteItems: [SongModel.key({ id: song2.id, musicianId: song2.musicianId })]
   })
 
   const results = await db
@@ -522,7 +524,7 @@ async function testBatchWrite(jayZ?: JayZ) {
   sortById(results.song)
   expect(results).toEqual({
     musician: [musician],
-    song: [song1, song2]
+    song: [song1]
   })
 }
 

--- a/src/test/dynamo/Beyonce.test.ts
+++ b/src/test/dynamo/Beyonce.test.ts
@@ -176,6 +176,10 @@ describe("Beyonce", () => {
     await testEmptyBatchGet()
   })
 
+  it("should write multiple items with empty fields at once", async () => {
+    await testPutAndRetrieveForItemWithEmptyFields()
+  })
+
   // GSIs
   it("should query GSI by model", async () => {
     await testGSIByModel()
@@ -253,6 +257,11 @@ describe("Beyonce", () => {
     const jayZ = await createJayZ()
     await testBatchWrite(jayZ)
   })
+
+  it("should write multiple items with empty fields at once with jayZ", async () => {
+    const jayZ = await createJayZ()
+    await testPutAndRetrieveForItemWithEmptyFields(jayZ)
+  })
 })
 
 async function testPutAndRetrieveItem(jayZ?: JayZ) {
@@ -262,6 +271,22 @@ async function testPutAndRetrieveItem(jayZ?: JayZ) {
 
   const result = await db.get(MusicianModel.key({ id: musician.id }))
   expect(result).toEqual(musician)
+}
+
+async function testPutAndRetrieveForItemWithEmptyFields(jayZ?: JayZ) {
+  const db = await setup(jayZ);
+  const [musician, song1, song2] = aMusicianWithTwoSongs();
+  song1.genre = undefined;
+  song2.genre = null;
+  await db.batchPut({ items: [musician, song1, song2] });
+
+  const result = await db.get(MusicianModel.key({ id: musician.id }));
+  expect(
+    await db.get(SongModel.key({ musicianId: musician.id, id: song1.id }))
+  ).toEqual(song1);
+  expect(
+    await db.get(SongModel.key({ musicianId: musician.id, id: song2.id }))
+  ).toEqual(song2);
 }
 
 async function testPutAndRetrieveItemWithUndefinedField(jayZ?: JayZ) {

--- a/src/test/dynamo/models.ts
+++ b/src/test/dynamo/models.ts
@@ -26,6 +26,7 @@ export interface Song {
   musicianId: string
   id: string
   title: string
+  genre?:string|null
   mp3: Buffer
 }
 

--- a/src/test/dynamo/query.test.ts
+++ b/src/test/dynamo/query.test.ts
@@ -295,7 +295,7 @@ async function testQueryWithReverseAndLimit(jayZ?: JayZ) {
 async function testPutAndRetrieveMultipleItems(jayZ?: JayZ) {
   const db = await setup(jayZ)
   const [musician, song1, song2] = aMusicianWithTwoSongs()
-  await db.executeTransaction({ putItems: [musician, song1, song2] })
+  await db.batchWriteWithTransaction({ putItems: [musician, song1, song2] })
 
   const result = await db
     .query(MusicianPartition.key({ id: musician.id }))

--- a/src/test/dynamo/util.ts
+++ b/src/test/dynamo/util.ts
@@ -64,10 +64,10 @@ export async function create25Songs(db: Beyonce): Promise<Song[]> {
   // Batch these to avoid DynamoDB local throwing errors about exceeding
   // the max payload size
   await Promise.all([
-    db.executeTransaction({ putItems: songs.slice(0, 5) }),
-    db.executeTransaction({ putItems: songs.slice(5, 10) }),
-    db.executeTransaction({ putItems: songs.slice(10, 15) }),
-    db.executeTransaction({ putItems: songs.slice(15) })
+    db.batchWriteWithTransaction({ putItems: songs.slice(0, 5) }),
+    db.batchWriteWithTransaction({ putItems: songs.slice(5, 10) }),
+    db.batchWriteWithTransaction({ putItems: songs.slice(10, 15) }),
+    db.batchWriteWithTransaction({ putItems: songs.slice(15) })
   ])
   return songs
 }


### PR DESCRIPTION
**What's in this PR?**
This PR is a superset of https://github.com/ginger-io/beyonce/pull/48, it contains its changes + additional changes. 

https://github.com/ginger-io/beyonce/pull/48 added a new `batchPut` method. But, given we recently added support for a `executeTransaction` method that allows for N put/delete operations -- it'd be more consistent to offer `batchWrite` and `batchWriteWithTransaction` methods.

So, that's what this PR does. 

`batchWrite` and `batchWriteWithTransaction` have different error-handling semantics, `batchWrite` may (or may not) return a list of failed put and delete operations that the caller can retry. This particular codepath needs unit tests, but we currently don't have an easy way to trigger "unprocessed item errors" in Dynamo (yet) -- so we'll add that in a subsequent PR. 