### PR TITLE
feat: Automatically split large batchGet calls into concurrent requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,10 @@ These options mirror the underlying [DynamoDB API](https://docs.aws.amazon.com/a
 
 ### BatchGet
 
+You can retrieve records in bulk via `batchGet`. DynamoDB allows retrieving a maximum of 100 items per
+`batchGet` query. So, if you ask for more than **100 keys** in a single Beyonce `batchGet` call, Beyonce will automatically split
+DynamoDB calls into N concurrent requests and join the results for you.
+
 ```TypeScript
 // Batch get several items
 const batchResults = await beyonce.batchGet({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ginger.io/beyonce",
-  "version": "0.0.60",
+  "version": "0.0.61",
   "description": "Type-safe DynamoDB query builder for TypeScript. Designed with single-table architecture in mind.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
**What's in this PR?**
This PR makes a change to `batchGet` to automatically split DynamoDB calls into N concurrent requests, _if_ the caller asks for more than 100 keys at once. 

Dynamo supports retrieving a max of 100 keys at a time. So, this should make things easier on consumers. Now they can ask for more than 100 items without having to do the request splitting themselves. 

Some future work here would be to allow partial success of batchGets. Right now we'll throw an error if any one of the concurrent requests fails. 