### PR TITLE
fix: Ensure pagedIterator preserves ordering of results when promises resolve out of order

### DIFF
--- a/src/test/dynamo/models.ts
+++ b/src/test/dynamo/models.ts
@@ -64,19 +64,27 @@ export function aMusicianWithTwoSongs(): [Musician, Song, Song] {
     }
   })
 
-  const song1 = SongModel.create({
+  const song1 = aSong({
     musicianId: "1",
     id: "2",
-    title: "Buffalo Soldier",
-    mp3: Buffer.from("fake-data", "utf8")
+    title: "Buffalo Soldier"
   })
 
-  const song2 = SongModel.create({
+  const song2 = aSong({
     musicianId: "1",
     id: "3",
-    title: "No Woman, No Cry",
-    mp3: Buffer.from("fake-data", "utf8")
+    title: "No Woman, No Cry"
   })
 
   return [musician, song1, song2]
+}
+
+export function aSong(partial?: Partial<Song>): Song {
+  return SongModel.create({
+    musicianId: "1",
+    id: "1",
+    title: "No Woman, No Cry",
+    mp3: Buffer.from("fake-data", "utf8"),
+    ...partial
+  })
 }


### PR DESCRIPTION
**What's in this PR?**

This PR fixes a bug where `pagedIterator` was doing something dumb (my fault). It was performing a side-effecting async `.map` on an array, which has two problems: 

1. Maps shouldn't perform side-effects
2. The side-effect it was performing was to push items onto a results array. 

2# above is particularly problematic as these Promises can resolve out of order, which meant that in some cases results would be returned out of order (relative to their sort key). 