### PR TITLE
fix: When Dynamo throws a transaction cancelled exception, include the reasons for cancellation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ginger.io/beyonce",
-  "version": "0.0.62",
+  "version": "0.0.63",
   "description": "Type-safe DynamoDB query builder for TypeScript. Designed with single-table architecture in mind.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
**What's in this PR**

When Dynamo throws a transaction cancelled exception, its HTTP response body includes a list of reasons for cancellation. But the error thrown from the sdk's Promise object does not include these reasons. 

So, per: https://github.com/aws/aws-sdk-js/issues/2464#issuecomment-503524701 -- we have to parse them out. 