### PR TITLE
feat: Add clientRequestToken option to batchWriteWithTransaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,8 @@ And all operations will either succeed, or fail.
 ```TypeScript
 await beyonce.batchWriteWithTransaction({ putItems: [author1], deleteItems: [Author.key({ id: author2.id })] })
 ```
+You can also pass a string `clientRequestToken` to `batchWriteWithTransaction` to force your operations to
+be idempotent, per the [AWS docs](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/transaction-apis.html#transaction-apis-txwriteitems-idempotency).
 
 ## Consistent Reads
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ginger.io/beyonce",
-  "version": "0.0.63",
+  "version": "0.0.64",
   "description": "Type-safe DynamoDB query builder for TypeScript. Designed with single-table architecture in mind.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -18,6 +18,7 @@
     "fast-json-stable-stringify": "^2.1.0",
     "js-yaml": "^3.13.1",
     "libsodium-wrappers": "^0.7.8",
+    "uuid": "^8.3.2",
     "yargs": "^15.3.1"
   },
   "devDependencies": {
@@ -27,6 +28,7 @@
     "@types/libsodium-wrappers": "^0.7.8",
     "@types/node": "^13.9.1",
     "@types/prettier": "^2.2.1",
+    "@types/uuid": "^8.3.0",
     "jest": "^26.6.3",
     "prettier": "^2.2.1",
     "ts-jest": "^26.5.2",

--- a/src/main/dynamo/Beyonce.ts
+++ b/src/main/dynamo/Beyonce.ts
@@ -161,13 +161,20 @@ export class Beyonce {
 
   /** Perform N Dynamo operations in an atomic transaction */
   async batchWriteWithTransaction<T extends TaggedModel>(params: {
+    clientRequestToken?: string
     putItems?: T[]
     deleteItems?: PartitionAndSortKey<T>[]
   }): Promise<void> {
-    const { putItems = [], deleteItems = [] } = params
+    const { clientRequestToken, putItems = [], deleteItems = [] } = params
     const maybeEncryptedPutPromises = putItems.map(async (item) => this.maybeEncryptItem(item))
     const maybeEncryptedItems = await Promise.all(maybeEncryptedPutPromises)
-    await transactWriteItems({ table: this.table, client: this.client, putItems: maybeEncryptedItems, deleteItems })
+    await transactWriteItems({
+      table: this.table,
+      client: this.client,
+      clientRequestToken,
+      putItems: maybeEncryptedItems,
+      deleteItems
+    })
   }
 
   query<T extends TaggedModel>(

--- a/yarn.lock
+++ b/yarn.lock
@@ -665,6 +665,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
 
+"@types/uuid@^8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
+  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
+
 "@types/yargs-parser@*":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
@@ -3610,7 +3615,7 @@ uuid@3.3.2, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
-uuid@^8.3.0:
+uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
**What's in this PR?**

This PR adds a `clientRequestToken` option to `batchWriteWithTransaction`. Passing this forces transactions to be idempotent [per the docs](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/transaction-apis.html#transaction-apis-txwriteitems-idempotency). 

So passing this should avoid "transaction cancelled errors" if simultaneous requests with the same content + `clientRequestToken` are submitted. 