### PR TITLE
feat: support uniqueness check on PUT

### DIFF
--- a/src/main/dynamo/Beyonce.ts
+++ b/src/main/dynamo/Beyonce.ts
@@ -162,19 +162,19 @@ export class Beyonce {
   /**
    * Perform N Dynamo operations in an atomic transaction.
    *
-   * @param params.putItems Set `mustBeUnique` to true on a record within putItems to cancel the transaction if a
+   * @param params.putItems Set `failIfNotUnique` to true on a record within putItems to cancel the transaction if a
    *  record with the same partition key and sort key (if applicable) already exists.
    */
   async batchWriteWithTransaction<T extends TaggedModel>(params: {
     clientRequestToken?: string
-    putItems?: (T & { mustBeUnique?: boolean })[]
+    putItems?: (T & { failIfNotUnique?: boolean })[]
     deleteItems?: PartitionAndSortKey<T>[]
   }): Promise<void> {
     const { clientRequestToken, putItems = [], deleteItems = [] } = params
-    const maybeEncryptedPutPromises = putItems.map(async ({ mustBeUnique, ...item }) => {
+    const maybeEncryptedPutPromises = putItems.map(async ({ failIfNotUnique, ...item }) => {
       return {
-        item: (await this.maybeEncryptItem(item as T)),
-        mustBeUnique
+        item: await this.maybeEncryptItem(item as T),
+        failIfNotUnique
       }
     })
     const maybeEncryptedItems = await Promise.all(maybeEncryptedPutPromises)

--- a/src/test/dynamo/Beyonce.test.ts
+++ b/src/test/dynamo/Beyonce.test.ts
@@ -198,7 +198,7 @@ describe("Beyonce", () => {
     await testBatchWriteWithTransaction()
   })
 
-  it("should cancel the transaction if matching record exists when mustBeUnique is true on put", async () => {
+  it("should cancel the transaction if matching record exists when failIfNotUnique is true on put", async () => {
     const jayZ = await createJayZ()
     const db = await setup(jayZ)
     const [musician, song1] = aMusicianWithTwoSongs()
@@ -207,12 +207,12 @@ describe("Beyonce", () => {
     // Putting the same items again should succeed.
     await db.batchWriteWithTransaction({ putItems: [musician, song1] })
 
-    // Putting the same items with `mustBeUnique: true` cancels the transaction.
+    // Putting the same items with `failIfNotUnique: true` cancels the transaction.
     await expect(
       db.batchWriteWithTransaction({
         putItems: [
           { ...musician, name: "updated" },
-          { ...song1, name: "updated", mustBeUnique: true }
+          { ...song1, name: "updated", failIfNotUnique: true }
         ]
       })
     ).rejects.toThrowError("ConditionalCheckFailed")


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1201082158239874/1202662582963198

This PR updates Beyonce to support checking for uniqueness when executing a `batchWriteWithTransaction` PUT. For example:

```
db.batchWriteWithTransaction({
	putItems: [
		{ ...item, failIfNotUnique: true }
	]
})
```

If there were already a record in DynamoDB with the same pk and sk (if applicable), the above would raise a "ConditionalCheckFailed" error since we set `failIfNotUnique: true`.

Related PR: https://github.com/ginger-io/ginger-vault-service/pull/645